### PR TITLE
fixed build_all.sh

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -6,8 +6,17 @@ else
 fi
 
 pushd firmware/libraries
-git submodule update --init -- fatfs PicoDVI tinyusb
+git submodule update --init -- no-OS-FatFS-SD-SPI-RPi-Pico
 popd
+
+pushd emulator
+make clean
+make 
+popd
+
+pushd basic
+make test
+popd basic
 
 make all
 


### PR DESCRIPTION
Minor corrections to build_all.sh
- init submodule no-OS-FatFS-SD-SPI-RPi-Pico
- make emulator first
- make basic tests to get test.bsc into right place.