### PR TITLE
Add github action for build and release.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: |
+        sudo apt update -y -qq
+        sudo apt install -y build-essential cmake git python3 python3-pip 64tass zip libsdl2-dev gcc-arm-none-eabi
+        pip install pillow
+        git submodule update --init
+        git clone --depth 1 --branch master https://github.com/raspberrypi/pico-sdk /usr/share/pico_sdk
+        
+    - name: Build
+      run: make
+
+    - name: 'Upload Artifact'
+      uses: actions/upload-artifact@v3
+      with:
+        name: release
+        path: release/neo6502.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release_linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt update -y -qq
+          sudo apt install -y build-essential cmake git python3 python3-pip 64tass zip libsdl2-dev gcc-arm-none-eabi
+          pip install pillow
+          git submodule update --init
+          git clone --depth 1 --branch master https://github.com/raspberrypi/pico-sdk /usr/share/pico_sdk
+
+      - name: Build
+        run: make
+
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v3
+        with:
+          name: release
+          path: release/neo6502.zip
+
+      - name: Upload to GitHub Release
+        uses: xresloader/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: "release/neo6502.zip"
+          tags: true


### PR DESCRIPTION
This adds two different github actions to the repository:

- build: is triggered for every commit and pull request to check if it still compiles
- release: is triggered for new release and will supply the neo6502.zip containing all available release file