### PR TITLE
IO Fixes (CLEAR reset, PIN 0/1)

### DIFF
--- a/basic/sources/arithmetic/unary/hardware/gpio.asm
+++ b/basic/sources/arithmetic/unary/hardware/gpio.asm
@@ -29,8 +29,11 @@ UnaryPin: ;; [pin(]
 		.DoWaitMessage
 		lda 	ControlError
 		bne 	_UPRange
-		lda 	ControlParameters
-		jmp 	ReturnBoolean
+		lda 	ControlParameters  			; return 0 / 1
+		beq 	_UPZero
+		lda 	#1
+_UPZero:		
+		jmp 	EXPUnaryReturnA
 _UPRange:
 		.error_range
 
@@ -44,5 +47,6 @@ _UPRange:
 ;
 ;		Date			Notes
 ;		==== 			=====
+;		22-02-24 		PIN() returns 0 or 1.
 ;
 ; ************************************************************************************************

--- a/basic/sources/commands/base/clear.asm
+++ b/basic/sources/commands/base/clear.asm
@@ -94,7 +94,12 @@ ClearCodeSetMemoryA:
 		;
 		stz		errCode
 		stz 	errCode+1
-		
+		;
+		; 		Reset the I/O system
+		;
+		.DoSendMessage 					
+		.byte 	10,1
+		.DoWaitMessage		
 		ply
 		rts
 
@@ -243,6 +248,7 @@ _CVExit:
 ;		16-01-24		CLEAR was looping (Y was reset to 3 causing it to loop infinitely)
 ;		23-01-24 		CLEAR resets all sprite settings as well.
 ; 		30-01-24 		CLEAR clears the sprite layer to maintain consistency.
+;		22-02-24 		CLEAR initialises UEXT
 ;
 ; ************************************************************************************************
 


### PR DESCRIPTION
CLEAR resets the system
PIN() now returns 0 or 1.