### PR TITLE
Add an API call for copying files.

### DIFF
--- a/emulator/src/core/hardware.cpp
+++ b/emulator/src/core/hardware.cpp
@@ -155,7 +155,7 @@ uint8_t FISRenameFile(const std::string& oldFilename, const std::string& newFile
 	else
 		printf("OK\n");
 
-	return !ec ? 1 : 0;
+	return !ec ? 0 : 1;
 }
 
 // ***************************************************************************************
@@ -176,7 +176,7 @@ uint8_t FISCopyFile(const std::string& oldFilename, const std::string& newFilena
 	else
 		printf("OK\n");
 
-	return !ec ? 1 : 0;
+	return !ec ? 0 : 1;
 }
 
 // ***************************************************************************************

--- a/emulator/src/core/hardware.cpp
+++ b/emulator/src/core/hardware.cpp
@@ -160,6 +160,27 @@ uint8_t FISRenameFile(const std::string& oldFilename, const std::string& newFile
 
 // ***************************************************************************************
 //
+//									 Copy file 
+//
+// ***************************************************************************************
+
+uint8_t FISCopyFile(const std::string& oldFilename, const std::string& newFilename) {
+	std::string oldAbspath = getAbspath(oldFilename);
+	std::string newAbspath = getAbspath(newFilename);
+	printf("FISCopyFile('%s', '%s') -> ", oldAbspath.c_str(), newAbspath.c_str());
+	std::error_code ec;
+	std::filesystem::copy(oldAbspath, newAbspath,
+		std::filesystem::copy_options::overwrite_existing, ec);
+	if (ec)
+		printf("%s\n", ec.message().c_str());
+	else
+		printf("OK\n");
+
+	return !ec ? 1 : 0;
+}
+
+// ***************************************************************************************
+//
 //									Delete file
 //
 // ***************************************************************************************

--- a/firmware/common/config/dispatch.config
+++ b/firmware/common/config/dispatch.config
@@ -192,6 +192,9 @@ group 3
 		*DERROR = FIOCloseDir();
 	}
 
+	function 20										// Function 20 copies a file
+		*DERROR = FIOCopyFile(DSPGetStdString(DPARAMS, 0), DSPGetStdString(DPARAMS, 2));
+
 	function 32 									// Function 32 is directory listing with wildcard
 		FIODirectory(DSPGetString(DCOMMAND,4));
 

--- a/firmware/common/include/interface/filesystem.h
+++ b/firmware/common/include/interface/filesystem.h
@@ -24,6 +24,7 @@ int FISDirectoryNext(char *buffer,int *isDirectory,int *fileSize);
 #define FIOATTR_HIDDEN   (1<<4)
 
 uint8_t FISRenameFile(const std::string& oldFilename, const std::string& newFilename);
+uint8_t FISCopyFile(const std::string& oldFilename, const std::string& newFilename);
 uint8_t FISDeleteFile(const std::string& filename);
 uint8_t FISCreateDirectory(const std::string& filename);
 uint8_t FISChangeDirectory(const std::string& filename);
@@ -52,6 +53,7 @@ uint8_t FIOReadFile(const std::string& fileName,uint16_t loadAddress,uint8_t *co
 uint8_t FIOReadFileBasic(const std::string& fileName,uint16_t loadAddress);
 uint8_t FIOWriteFile(const std::string& filename, uint16_t startAddress,uint16_t size);
 uint8_t FIORenameFile(const std::string& oldFilename, const std::string& newFilename);
+uint8_t FIOCopyFile(const std::string& oldFilename, const std::string& newFilename);
 uint8_t FIODeleteFile(const std::string& filename);
 uint8_t FIOCreateDirectory(const std::string& filename);
 uint8_t FIOChangeDirectory(const std::string& filename);

--- a/firmware/common/sources/interface/fileinterface.cpp
+++ b/firmware/common/sources/interface/fileinterface.cpp
@@ -185,6 +185,16 @@ uint8_t FIORenameFile(const std::string& oldFilename, const std::string& newFile
 
 // ***************************************************************************************
 //
+//									 Copy file 
+//
+// ***************************************************************************************
+
+uint8_t FIOCopyFile(const std::string& oldFilename, const std::string& newFilename) {
+	return FISCopyFile(oldFilename, newFilename);
+}
+
+// ***************************************************************************************
+//
 //									Delete File
 //
 // ***************************************************************************************

--- a/firmware/sources/hardware/fileimplementation.cpp
+++ b/firmware/sources/hardware/fileimplementation.cpp
@@ -62,13 +62,16 @@ uint8_t FISCopyFile(const std::string& oldFilename, const std::string& newFilena
 	std::unique_ptr<uint8_t[]> buffer(new (std::nothrow) uint8_t[COPY_BUFFER_SIZE]);
 	if (!oldFile || !newFile || !buffer) {
 		// Out of memory.
+		// CONWriteString("Out of memory\r");
 		return 1;
 	}
 
 	FRESULT result = f_open(&*oldFile, oldFilename.c_str(), FA_READ);
+	// CONWriteString("Opened '%s' for read -> %d\r", oldFilename.c_str(), result);
 	if (result == FR_OK)
 	{
-		result = f_open(&*newFile, newFilename.c_str(), FA_WRITE);
+		result = f_open(&*newFile, newFilename.c_str(), FA_WRITE|FA_CREATE_ALWAYS);
+		// CONWriteString("Opened '%s' for write -> %d\r", newFilename.c_str(), result);
 		if (result == FR_OK)
 		{
 			for (;;) {

--- a/firmware/sources/hardware/fileimplementation.cpp
+++ b/firmware/sources/hardware/fileimplementation.cpp
@@ -13,6 +13,10 @@
 #include "common.h"
 #include <inttypes.h>
 #include "ff.h"
+#include <memory>
+#include <functional>
+
+static constexpr int COPY_BUFFER_SIZE = 1024;
 
 static FIL fileHandles[FIO_NUM_FILES];
 
@@ -40,6 +44,61 @@ uint8_t FISRenameFile(const std::string& oldFilename, const std::string& newFile
 	FRESULT result = f_rename(oldFilename.c_str(), newFilename.c_str());
 	return (result == FR_OK) ? 0 : 1;
 }
+
+// ***************************************************************************************
+//
+//									Copy File
+//
+// ***************************************************************************************
+
+uint8_t FISCopyFile(const std::string& oldFilename, const std::string& newFilename) {
+	STOInitialise();
+
+	// Our stack is quite small and there's a lot of buffer here, so
+	// allocate them from the heap. The unique_ptr<> causes them to be
+	// cleaned up automatically when the function ends.
+	std::unique_ptr<FIL> oldFile(new (std::nothrow) FIL);
+	std::unique_ptr<FIL> newFile(new (std::nothrow) FIL);
+	std::unique_ptr<uint8_t[]> buffer(new (std::nothrow) uint8_t[COPY_BUFFER_SIZE]);
+	if (!oldFile || !newFile || !buffer) {
+		// Out of memory.
+		return 1;
+	}
+
+	FRESULT result = f_open(&*oldFile, oldFilename.c_str(), FA_READ);
+	if (result == FR_OK)
+	{
+		result = f_open(&*newFile, newFilename.c_str(), FA_WRITE);
+		if (result == FR_OK)
+		{
+			for (;;) {
+				UINT bytesRead;
+				result = f_read(&*oldFile, buffer.get(), COPY_BUFFER_SIZE, &bytesRead);
+				if (result != FR_OK)
+					break;
+				if (bytesRead == 0)
+					break;
+				
+				UINT bytesWritten;
+				result = f_write(&*newFile, buffer.get(), bytesRead, &bytesWritten);
+				if (result != FR_OK)
+					break;
+				if (bytesWritten != bytesRead) {
+					// Disk full.
+					result = FR_DISK_ERR;
+					break;
+				}
+			}
+
+			f_close(&*newFile);
+		}
+
+		f_close(&*oldFile);
+	}
+
+	return (result == FR_OK) ? 0 : 1;
+}
+
 
 // ***************************************************************************************
 //


### PR DESCRIPTION
It's even tested!

Performance on my rather bad USB stick is ~4-6 kB/s, which is miserable, but probably fine for this platform. It's using a 1kB buffer allocated when needed from the heap (and then freed again). We could probably make this bigger but let's leave it like this for now until we know how much spare heap we're going to have.

Fixes: #210 