### PR TITLE
more examples

### DIFF
--- a/examples/C/hello.c
+++ b/examples/C/hello.c
@@ -4,7 +4,7 @@
 |*|
 |*| This is a very basic C program,
 |*| which sounds a beep and displays some text at a precise screen location.
-|*| Refer to documents/release/api.pdf for more API functions.
+|*| Refer to api.pdf for more API functions.
 |*|
 |*| To compile and run:
 |*|   $ export CC65_HOME=/usr/share/cc65
@@ -24,46 +24,7 @@
 #include "neo6502.h"
 
 
-/*\
-|*| Play sound effect - (API Group 8, Function 5)
-\*/
-void SoundEffect(uint8_t sound_ch , uint8_t sound_effect)
-{
-  *API_FUNCTION_ADDR     = API_FN_PLAY_SOUND ;
-  API_PARAMETERS_ADDR[0] = sound_ch          ;
-  API_PARAMETERS_ADDR[1] = sound_effect      ;
-  *API_COMMAND_ADDR      = API_GROUP_SOUND   ;
-}
-
-/*\
-|*| Set cursor position - (API Group 2, Function 7)
-\*/
-void SetCursorPosition(uint8_t x_pos , uint8_t y_pos)
-{
-  *API_FUNCTION_ADDR     = API_FN_CURSOR_POS ;
-  API_PARAMETERS_ADDR[0] = x_pos             ;
-  API_PARAMETERS_ADDR[1] = y_pos             ;
-  *API_COMMAND_ADDR      = API_GROUP_CONSOLE ;
-}
-
-/*\
-|*| Write character to console - (API Group 2, Function 6)
-\*/
-int write(int /* fildes */ , const unsigned char* buf , unsigned count)
-{
-  while (count--)
-  {
-    while(*API_COMMAND_ADDR) {}
-
-    *API_FUNCTION_ADDR   = API_FN_WRITE_CHAR ;
-    *API_PARAMETERS_ADDR = *buf++            ;
-    *API_COMMAND_ADDR    = API_GROUP_CONSOLE ;
-  }
-
-  return 0 ;
-}
-
-int demo_bug()
+void demo_bug()
 {
   unsigned char buf[33] ;
   uint8_t char_n ;
@@ -86,11 +47,11 @@ int demo_bug()
 
 int main()
 {
-  SoundEffect(API_SOUND_CH_00 , API_SOUND_EFFECT_06) ;
+  SoundEffect(API_SOUND_CH_00 , API_SFX_COIN) ;
 
   SetCursorPosition(0 , 22) ;
   puts("                   Hello world!") ;
-  puts("                                                    ") ; // 52 blanks
+  puts("                                                     ") ; // 53 blanks
 
 
   // BUG: https://github.com/paulscottrobson/neo6502-firmware/issues/98

--- a/examples/C/neo6502.h
+++ b/examples/C/neo6502.h
@@ -6,19 +6,67 @@
 
 /* Neo6502 Kernel API control addresses */
 
-uint8_t* API_COMMAND_ADDR    = (uint8_t*)0xFF00 ; // function group address
-uint8_t* API_FUNCTION_ADDR   = (uint8_t*)0xFF01 ; // function address
-uint8_t* API_PARAMETERS_ADDR = (uint8_t*)0xFF04 ; // function parameters base address (8 bytes)
+uint16_t* ControlPort         = (uint16_t*)0xFF00 ;
+uint16_t* API_COMMAND_ADDR    = ControlPort + 0 ; // function group address
+uint16_t* API_FUNCTION_ADDR   = ControlPort + 1 ; // function address
+uint16_t* API_PARAMETERS_ADDR = ControlPort + 4 ; // function parameters base address (+0..7)
 
 
-/* Neo6502 Kernel API control codes (see documents/release/api.pdf) */
+/* Neo6502 Kernel API control codes (see api.pdf) */
 
-// Console functions (Group 2)
-uint8_t API_GROUP_CONSOLE   = (uint8_t )0x02 ; // API function group ID
-uint8_t API_FN_WRITE_CHAR   = (uint8_t )0x06 ; // API function ID
-uint8_t API_FN_CURSOR_POS   = (uint8_t )0x07 ; // API function ID
-// Sound functions (Group 8)
-uint8_t API_GROUP_SOUND     = (uint8_t )0x08 ; // API function group ID
-uint8_t API_FN_PLAY_SOUND   = (uint8_t )0x05 ; // API function ID
-uint8_t API_SOUND_CH_00     = (uint8_t )0x00 ; // API function parameter ID
-uint8_t API_SOUND_EFFECT_06 = (uint8_t )0x06 ; // API function parameter ID
+/*\
+|*| Console functions (Group 2)
+\*/
+uint8_t API_GROUP_CONSOLE = (uint8_t )0x02 ; // API function group
+uint8_t API_FN_WRITE_CHAR = (uint8_t )0x06 ; // API function
+uint8_t API_FN_CURSOR_POS = (uint8_t )0x07 ; // API function
+
+/*\
+|*| Sound functions (Group 8)
+\*/
+uint8_t API_GROUP_SOUND   = (uint8_t )0x08 ; // API function group
+uint8_t API_FN_PLAY_SOUND = (uint8_t )0x05 ; // API function
+uint8_t API_SOUND_CH_00   = (uint8_t )0x00 ; // API parameter (channel index)
+uint8_t API_SFX_COIN      = (uint8_t )0x06 ; // API parameter (sound effect)
+
+
+/* Neo6502 Kernel API functions */
+
+/*\
+|*| Play sound effect - (API Group 8, Function 5)
+\*/
+void SoundEffect(uint8_t sound_ch , uint8_t sound_effect)
+{
+  *API_FUNCTION_ADDR     = API_FN_PLAY_SOUND ;
+  API_PARAMETERS_ADDR[0] = sound_ch          ;
+  API_PARAMETERS_ADDR[1] = sound_effect      ;
+  *API_COMMAND_ADDR      = API_GROUP_SOUND   ;
+}
+
+/*\
+|*| Set cursor position - (API Group 2, Function 7)
+\*/
+void SetCursorPosition(uint8_t x_pos , uint8_t y_pos)
+{
+  *API_FUNCTION_ADDR     = API_FN_CURSOR_POS ;
+  API_PARAMETERS_ADDR[0] = x_pos             ;
+  API_PARAMETERS_ADDR[1] = y_pos             ;
+  *API_COMMAND_ADDR      = API_GROUP_CONSOLE ;
+}
+
+/*\
+|*| Write character to console - (API Group 2, Function 6)
+\*/
+int write(int /* fildes */ , const unsigned char* buf , unsigned count)
+{
+  while (count--)
+  {
+    while(*API_COMMAND_ADDR) {}
+
+    *API_FUNCTION_ADDR   = API_FN_WRITE_CHAR ;
+    *API_PARAMETERS_ADDR = *buf++            ;
+    *API_COMMAND_ADDR    = API_GROUP_CONSOLE ;
+  }
+
+  return 0 ;
+}

--- a/examples/assembly/build_graphics_asm.sh
+++ b/examples/assembly/build_graphics_asm.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Graphics assembly example for the Neo6502 (build script)
+# SPDX-License-Identifier: CC0-1.0
+#
+# requires '64tass' assembler
+
+
+# environment checks
+which 64tass > /dev/null || ! echo "could not find '64tass' program" || exit 1
+
+
+cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+# cleanup
+rm -f graphics.lst graphics.neo
+
+# assemble
+64tass --mw65c02 --nostart --list graphics.lst --output=graphics.neo graphics.asm
+
+# launch emulator
+test -f graphics.neo && ../../bin/neo graphics.neo@800 cold
+
+cd -

--- a/examples/assembly/build_medody_asm.sh
+++ b/examples/assembly/build_medody_asm.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Melody assembly example for the Neo6502 (build script)
+# SPDX-License-Identifier: CC0-1.0
+#
+# requires '64tass' assembler
+
+
+# environment checks
+which 64tass > /dev/null || ! echo "could not find '64tass' program" || exit 1
+
+
+# cleanup
+rm -f melody.lst melody.neo
+
+# assemble
+64tass --mw65c02 --nostart --list melody.lst --output=melody.neo melody.asm
+
+# launch emulator
+test -f melody.neo && ../../bin/neo melody.neo@800 cold

--- a/examples/assembly/graphics.asm
+++ b/examples/assembly/graphics.asm
@@ -1,0 +1,198 @@
+; Graphics assembly example for the Neo6502
+;
+; Copyright 2024 bill-auger <bill-auger@programmer.net>
+; SPDX-License-Identifier: CC0-1.0
+;
+; This is a very basic assembly program,
+; which demonstrates how to use the API to draw some graphics.
+; Refer to api.pdf for more API functions.
+;
+; To assemble and run:
+;   $ 64tass --mw65c02 --nostart --output=graphics.neo graphics.asm
+;   $ ../bin/neo graphics.neo@800 cold
+
+
+; RAM load address
+* = $800
+
+; Neo6502 Kernel API convenience macros
+.include 'neo6502.asm.inc'
+
+
+start:
+  ;---------------------------------------;
+  ; Draw line - (API Group 5, Function 2) ;
+  ;---------------------------------------;
+
+  lda API_FN_DRAW_LINE
+  sta API_FUNCTION
+  lda #$00               ; Begin X low-byte
+  sta API_PARAMETERS + 0
+  lda #$00               ; Begin X high-byte
+  sta API_PARAMETERS + 1
+  lda #$00               ; Begin Y low-byte
+  sta API_PARAMETERS + 2
+  lda #$00               ; Begin Y high-byte
+  sta API_PARAMETERS + 3
+  lda #$E0               ; End X low-byte
+  sta API_PARAMETERS + 4
+  lda #$00               ; End X high-byte
+  sta API_PARAMETERS + 5
+  lda #$E0               ; End Y low-byte
+  sta API_PARAMETERS + 6
+  lda #$00               ; End Y high-byte
+  sta API_PARAMETERS + 7
+  lda API_GROUP_GRAPHICS
+  sta API_COMMAND
+
+
+  ;--------------------------------------------;
+  ; Draw Rectangle - (API Group 5, Function 3) ;
+  ;--------------------------------------------;
+
+  lda API_FN_DRAW_RECT
+  sta API_FUNCTION
+  lda #$00               ; Begin X low-byte
+  sta API_PARAMETERS + 0
+  lda #$00               ; Begin X high-byte
+  sta API_PARAMETERS + 1
+  lda #$00               ; Begin Y low-byte
+  sta API_PARAMETERS + 2
+  lda #$00               ; Begin Y high-byte
+  sta API_PARAMETERS + 3
+  lda #$E0               ; End X low-byte
+  sta API_PARAMETERS + 4
+  lda #$00               ; End X high-byte
+  sta API_PARAMETERS + 5
+  lda #$E0               ; End Y low-byte
+  sta API_PARAMETERS + 6
+  lda #$00               ; End Y high-byte
+  sta API_PARAMETERS + 7
+  lda API_GROUP_GRAPHICS
+  sta API_COMMAND
+
+
+  ;-----------------------------------------;
+  ; Draw Elipse - (API Group 5, Function 4) ;
+  ;-----------------------------------------;
+
+  lda API_FN_DRAW_ELIPSE
+  sta API_FUNCTION
+  lda #$00               ; Begin X low-byte
+  sta API_PARAMETERS + 0
+  lda #$00               ; Begin X high-byte
+  sta API_PARAMETERS + 1
+  lda #$00               ; Begin Y low-byte
+  sta API_PARAMETERS + 2
+  lda #$00               ; Begin Y high-byte
+  sta API_PARAMETERS + 3
+  lda #$E0               ; End X low-byte
+  sta API_PARAMETERS + 4
+  lda #$00               ; End X high-byte
+  sta API_PARAMETERS + 5
+  lda #$E0               ; End Y low-byte
+  sta API_PARAMETERS + 6
+  lda #$00               ; End Y high-byte
+  sta API_PARAMETERS + 7
+  lda API_GROUP_GRAPHICS
+  sta API_COMMAND
+
+
+  ;------------------------------------------;
+  ; Set graphics - (API Group 5, Function 1) ;
+  ;------------------------------------------;
+
+  ; set color mask and fill mode to modify existing pixels
+  lda API_FN_SET_GFX
+  sta API_FUNCTION
+  lda #$0F               ; AND existing pixel color
+  sta API_PARAMETERS + 0
+  lda #$08               ; XOR the AND'ed color
+  sta API_PARAMETERS + 1
+  lda #$01               ; fill mode - solid
+  sta API_PARAMETERS + 2
+  lda #$00               ; TODO: seems to have no effect
+  sta API_PARAMETERS + 3 ;
+  lda #$00               ; flip mode - none
+  sta API_PARAMETERS + 4 ;
+  lda API_GROUP_GRAPHICS
+  sta API_COMMAND
+
+
+  ;-----------------------------------------;
+  ; Draw Elipse - (API Group 5, Function 4) ;
+  ;-----------------------------------------;
+
+  ; a smaller elipse, in masked fill mode
+  lda API_FN_DRAW_ELIPSE
+  sta API_FUNCTION
+  lda #$20               ; Begin X low-byte
+  sta API_PARAMETERS + 0
+  lda #$00               ; Begin X high-byte
+  sta API_PARAMETERS + 1
+  lda #$20               ; Begin Y low-byte
+  sta API_PARAMETERS + 2
+  lda #$00               ; Begin Y high-byte
+  sta API_PARAMETERS + 3
+  lda #$C0               ; End X low-byte
+  sta API_PARAMETERS + 4
+  lda #$00               ; End X high-byte
+  sta API_PARAMETERS + 5
+  lda #$C0               ; End Y low-byte
+  sta API_PARAMETERS + 6
+  lda #$00               ; End Y high-byte
+  sta API_PARAMETERS + 7
+  lda API_GROUP_GRAPHICS
+  sta API_COMMAND
+
+
+  ;------------------------------------------;
+  ; Set graphics - (API Group 5, Function 1) ;
+  ;------------------------------------------;
+
+  ; set opaque color and fill mode to obscure existing pixels
+  lda API_FN_SET_GFX
+  sta API_FUNCTION
+  lda #$00               ; AND $00 to mask out underlying pixels
+  sta API_PARAMETERS + 0
+  lda #$0D               ; XOR $0C to set new color
+  sta API_PARAMETERS + 1
+  lda #$01               ; fill mode - solid
+  sta API_PARAMETERS + 2
+  lda #$00               ; TODO: seems to have no effect
+  sta API_PARAMETERS + 3 ;
+  lda #$00               ; flip mode - none
+  sta API_PARAMETERS + 4 ;
+  lda API_GROUP_GRAPHICS
+  sta API_COMMAND
+
+
+  ;-----------------------------------------;
+  ; Draw Elipse - (API Group 5, Function 4) ;
+  ;-----------------------------------------;
+
+  ; a yet smaller elipse, in opaque fill mode
+  lda API_FN_DRAW_ELIPSE
+  sta API_FUNCTION
+  lda #$40               ; Begin X low-byte
+  sta API_PARAMETERS + 0
+  lda #$00               ; Begin X high-byte
+  sta API_PARAMETERS + 1
+  lda #$40               ; Begin Y low-byte
+  sta API_PARAMETERS + 2
+  lda #$00               ; Begin Y high-byte
+  sta API_PARAMETERS + 3
+  lda #$A0               ; End X low-byte
+  sta API_PARAMETERS + 4
+  lda #$00               ; End X high-byte
+  sta API_PARAMETERS + 5
+  lda #$A0               ; End Y low-byte
+  sta API_PARAMETERS + 6
+  lda #$00               ; End Y high-byte
+  sta API_PARAMETERS + 7
+  lda API_GROUP_GRAPHICS
+  sta API_COMMAND
+
+
+end:
+  jmp end ; infinite loop

--- a/examples/assembly/hello.asm
+++ b/examples/assembly/hello.asm
@@ -7,7 +7,7 @@
 ; which sounds a beep and displays some text at a precise screen location.
 ; It demonstrates how to use some of the limited-case convenience macros,
 ; and also how to use the complete API.
-; Refer to documents/release/api.pdf for more API functions.
+; Refer to api.pdf for more API functions.
 ;
 ; To assemble and run:
 ;   $ 64tass --mw65c02 --nostart --output=hello.neo hello.asm
@@ -35,14 +35,14 @@ start:
   ; Play sound effect - (API Group 8, Function 5) ;
   ;-----------------------------------------------;
 
-  lda API_SOUND_CH_00     ; sound effect channel        (API::sound->play->channel)
-  sta DParameters + 0     ; set API 'Parameter0'        (API::sound->play->channel)
-  lda API_SOUND_EFFECT_06 ; sound effect index          (API::sound->play->effect)
-  sta DParameters + 1     ; set API 'Parameter1'        (API::sound->play->effect)
-  lda API_FN_PLAY_SOUND   ; sound effect function       (API::sound->play)
-  sta DFunction           ; set API 'Function'          (API::sound->play)
-  lda API_GROUP_SOUND     ; 'Sound' API function group  (API::sound)
-  sta DCommand            ; trigger 'Sound' API routine (API::sound)
+  lda API_SOUND_CH_00    ; sound channel               (API::sound->play->channel)
+  sta API_PARAMETERS + 0 ; set API 'Parameter0'        (API::sound->play->channel)
+  lda API_SFX_COIN       ; sound effect index          (API::sound->play->effect)
+  sta API_PARAMETERS + 1 ; set API 'Parameter1'        (API::sound->play->effect)
+  lda API_FN_PLAY_SOUND  ; sound effect function       (API::sound->play)
+  sta API_FUNCTION       ; set API 'Function'          (API::sound->play)
+  lda API_GROUP_SOUND    ; 'Sound' API function group  (API::sound)
+  sta API_COMMAND        ; trigger 'Sound' API routine (API::sound)
 
 
   ;--------------------------------------------------;
@@ -50,21 +50,21 @@ start:
   ;--------------------------------------------------;
 
   ; reposition the cursor to overwrite the default welcome text
-  lda API_FN_CURSOR_POS ; set cursor position function  (API::console->cursor)
-  sta DFunction         ; set API 'Function'            (API::console->cursor)
-  lda CURSOR_POS_X      ; cursor 'X' coordinate         (API::console->cursor->x)
-  sta DParameters + 0   ; set API 'Parameter0'          (API::console->cursor->x)
-  lda CURSOR_POS_Y      ; cursor 'Y' coordinate         (API::console->cursor->y)
-  sta DParameters + 1   ; set API 'Parameter1'          (API::console->cursor->y)
-  lda API_GROUP_CONSOLE ; 'Console' API function group  (API::console)
-  sta DCommand          ; trigger 'Console' API routine (API::console)
+  lda API_FN_SET_CURSOR_POS ; set cursor position function  (API::console->cursor)
+  sta API_FUNCTION          ; set API 'Function'            (API::console->cursor)
+  lda CURSOR_POS_X          ; cursor 'X' coordinate         (API::console->cursor->x)
+  sta API_PARAMETERS + 0    ; set API 'Parameter0'          (API::console->cursor->x)
+  lda CURSOR_POS_Y          ; cursor 'Y' coordinate         (API::console->cursor->y)
+  sta API_PARAMETERS + 1    ; set API 'Parameter1'          (API::console->cursor->y)
+  lda API_GROUP_CONSOLE     ; 'Console' API function group  (API::console)
+  sta API_COMMAND           ; trigger 'Console' API routine (API::console)
 
   ; this simply repeats the same routine as the previous block,
   ; but using the generic convenience macro, for the sake of demonstration
   lda CURSOR_POS_X
-  sta DParameters + 0
+  sta API_PARAMETERS + 0
   lda CURSOR_POS_Y
-  sta DParameters + 1
+  sta API_PARAMETERS + 1
   #DoSendMessage ; send command 2,7
   .byte 2,7
 
@@ -81,21 +81,21 @@ start:
   jsr WriteCharacter
 
   ; next, print the welcome message (a string of characters), using the API
-  ldx #0                ; initialize string iteration index
-  lda API_FN_WRITE_CHAR ; console write function        (API::console->write)
-  sta DFunction         ; set API 'Function'            (API::console->write)
+  ldx #0                 ; initialize string iteration index
+  lda API_FN_WRITE_CHAR  ; console write function        (API::console->write)
+  sta API_FUNCTION       ; set API 'Function'            (API::console->write)
 print_next_char:
-  lda DCommand          ; previous API routine status
-  bne print_next_char   ; wait for previous API routine to complete
+  lda API_COMMAND        ; previous API routine status
+  bne print_next_char    ; wait for previous API routine to complete
 
-  lda hello_msg , x     ; next character of 'hello_msg' (API::console->write->char)
-  beq end               ; test for string end null byte
-  sta DParameters + 0   ; set API 'Parameter0'          (API::console->write->char)
-  lda API_GROUP_CONSOLE ; 'Console' API function group  (API::console)
-  sta DCommand          ; trigger 'Console' API routine (API::console)
+  lda hello_msg , x      ; next character of 'hello_msg' (API::console->write->char)
+  beq end                ; test for string end null byte
+  sta API_PARAMETERS + 0 ; set API 'Parameter0'          (API::console->write->char)
+  lda API_GROUP_CONSOLE  ; 'Console' API function group  (API::console)
+  sta API_COMMAND        ; trigger 'Console' API routine (API::console)
 
-  inx                   ; increment iteration index
-  jmp print_next_char   ; continue 'hello_msg' print loop
+  inx                    ; increment iteration index
+  jmp print_next_char    ; continue 'hello_msg' print loop
 
 end:
   jmp end ; infinite loop
@@ -106,11 +106,11 @@ end:
 ;--------------;
 
 hello_msg:
-  .text "                   Hello Neo6502"                     ; line 1 to display
-  .text 13                                                     ; newline
-  .text "                                                    " ; 52 blanks
-  .text 13                                                     ; newline
-  .text "          Now you're playing with Neo Power!"         ; line 2 to display
-  .text 13                                                     ; newline
-  .text "              (Some assembly required)"               ; line 3 to display
-  .text 0                                                      ; null-terminated
+  .text "                   Hello Neo6502"                      ; line 1 to display
+  .text 13                                                      ; newline
+  .text "                                                     " ; 53 blanks
+  .text 13                                                      ; newline
+  .text "          Now you're playing with Neo Power!"          ; line 2 to display
+  .text 13                                                      ; newline
+  .text "              (Some assembly required)"                ; line 3 to display
+  .text 0                                                       ; null-terminated

--- a/examples/assembly/melody.asm
+++ b/examples/assembly/melody.asm
@@ -1,0 +1,177 @@
+; Melody assembly example for the Neo6502
+;
+; Copyright 2024 bill-auger <bill-auger@programmer.net>
+; SPDX-License-Identifier: CC0-1.0
+;
+; This is a very basic assembly program,
+; which demonstrates how to use the API to play a melody.
+; Refer to api.pdf for more API functions.
+;
+; To assemble and run:
+;   $ 64tass --mw65c02 --nostart --output=melody.neo melody.asm
+;   $ ../bin/neo melody.neo@800 cold
+
+
+; RAM load address
+* = $800
+
+; Neo6502 Kernel API convenience macros
+.include 'neo6502.asm.inc'
+
+
+;--------------;
+; Main Program ;
+;--------------;
+
+start:
+  ;-----------------------------------------;
+  ; Queue sound - (API Group 8, Function 4) ;
+  ;-----------------------------------------;
+
+  ; these note durations will be 60s / 80 / 3
+  ; that is, 6/8 compound time eighth-notes at 80BPM
+  ; for 4/4 time eighth-notes, divide API_TEMPO_* by 2 instead
+  lda API_SOUND_CH_00    ; sound channel               (API::sound->queue->channel)
+  sta API_PARAMETERS + 0 ; set API 'Parameter0'        (API::sound->queue->channel)
+  lda <API_NOTE_C4       ; sound frequency low byte    (API::sound->queue->frequency)
+  sta API_PARAMETERS + 1 ; set API 'Parameter1'        (API::sound->queue->frequency)
+  lda >API_NOTE_C4       ; sound frequency high byte   (API::sound->queue->frequency)
+  sta API_PARAMETERS + 2 ; set API 'Parameter2'        (API::sound->queue->frequency)
+  lda <API_TEMPO_80 / 3  ; sound duration low byte     (API::sound->queue->duration)
+  sta API_PARAMETERS + 3 ; set API 'Parameter3'        (API::sound->queue->duration)
+  lda >API_TEMPO_80 / 3  ; sound duration high byte    (API::sound->queue->duration)
+  sta API_PARAMETERS + 4 ; set API 'Parameter4'        (API::sound->queue->duration)
+  lda <API_SLIDE_NONE    ; sound slide low byte        (API::sound->queue->slide)
+  sta API_PARAMETERS + 5 ; set API 'Parameter5'        (API::sound->queue->slide)
+  lda >API_SLIDE_NONE    ; sound slide high byte       (API::sound->queue->slide)
+  sta API_PARAMETERS + 6 ; set API 'Parameter6'        (API::sound->queue->slide)
+  lda API_SOUND_SRC_BEEP ; sound source                (API::sound->queue->source)
+  sta API_PARAMETERS + 7 ; set API 'Parameter7'        (API::sound->queue->source)
+  lda API_FN_QUEUE_SOUND ; queue sound function        (API::sound->queue)
+  sta API_FUNCTION       ; set API 'Function'          (API::sound->queue)
+  lda API_GROUP_SOUND    ; 'Sound' API function group  (API::sound)
+  sta API_COMMAND        ; trigger 'Sound' API routine (API::sound)
+
+  lda <API_NOTE_E4
+  sta API_PARAMETERS + 1
+  lda >API_NOTE_E4
+  sta API_PARAMETERS + 2
+  lda API_GROUP_SOUND
+  sta API_COMMAND
+
+  lda <API_NOTE_G4
+  sta API_PARAMETERS + 1
+  lda >API_NOTE_G4
+  sta API_PARAMETERS + 2
+  lda API_GROUP_SOUND
+  sta API_COMMAND
+
+  lda <API_NOTE_C5
+  sta API_PARAMETERS + 1
+  lda >API_NOTE_C5
+  sta API_PARAMETERS + 2
+  lda API_GROUP_SOUND
+  sta API_COMMAND
+
+  lda <API_NOTE_G4
+  sta API_PARAMETERS + 1
+  lda >API_NOTE_G4
+  sta API_PARAMETERS + 2
+  lda API_GROUP_SOUND
+  sta API_COMMAND
+
+  lda <API_NOTE_E4
+  sta API_PARAMETERS + 1
+  lda >API_NOTE_E4
+  sta API_PARAMETERS + 2
+  lda API_GROUP_SOUND
+  sta API_COMMAND
+
+  lda <API_NOTE_C4
+  sta API_PARAMETERS + 1
+  lda >API_NOTE_C4
+  sta API_PARAMETERS + 2
+  lda API_GROUP_SOUND
+  sta API_COMMAND
+
+  ; this "note" is silent (a rest note)
+  lda <API_NOTE_REST
+  sta API_PARAMETERS + 1
+  sta API_PARAMETERS + 2 ; high and low bytes are the same (0)
+  lda API_GROUP_SOUND
+  sta API_COMMAND
+
+  ; the next note durations will be 60s / 80 / 6
+  ; twice as rapid that is, 6/8 compound time sixteenth-notes at 80BPM
+  lda <API_TEMPO_80 / 6
+  sta API_PARAMETERS + 3
+  lda >API_TEMPO_80 / 6
+  sta API_PARAMETERS + 4
+
+  lda <API_NOTE_C5
+  sta API_PARAMETERS + 1
+  lda >API_NOTE_C5
+  sta API_PARAMETERS + 2
+  lda API_GROUP_SOUND
+  sta API_COMMAND
+
+  lda <API_NOTE_G4
+  sta API_PARAMETERS + 1
+  lda >API_NOTE_G4
+  sta API_PARAMETERS + 2
+  lda API_GROUP_SOUND
+  sta API_COMMAND
+
+  lda <API_NOTE_C4
+  sta API_PARAMETERS + 1
+  lda >API_NOTE_C4
+  sta API_PARAMETERS + 2
+  lda API_GROUP_SOUND
+  sta API_COMMAND
+
+  ; original tempo
+  lda <API_TEMPO_80 / 3
+  sta API_PARAMETERS + 3
+  lda >API_TEMPO_80 / 3
+  sta API_PARAMETERS + 4
+
+  ; two rests
+  lda <API_NOTE_REST
+  sta API_PARAMETERS + 1
+  sta API_PARAMETERS + 2
+  lda API_GROUP_SOUND
+  sta API_COMMAND
+  lda API_GROUP_SOUND
+  sta API_COMMAND
+
+  ; slide (dotted quarter)
+  lda <API_NOTE_C4
+  sta API_PARAMETERS + 1
+  lda >API_NOTE_C4
+  sta API_PARAMETERS + 2
+  lda <API_TEMPO_80
+  sta API_PARAMETERS + 3
+  lda >API_TEMPO_80
+  sta API_PARAMETERS + 4
+  lda <API_SLIDE_FAST
+  sta API_PARAMETERS + 5
+  lda >API_SLIDE_FAST
+  sta API_PARAMETERS + 6
+  lda API_GROUP_SOUND
+  sta API_COMMAND
+
+  ; ending note
+  lda <API_NOTE_C5
+  sta API_PARAMETERS + 1
+  lda >API_NOTE_C5
+  sta API_PARAMETERS + 2
+  lda <API_SLIDE_NONE
+  sta API_PARAMETERS + 5
+  lda >API_SLIDE_NONE
+  sta API_PARAMETERS + 6
+  lda API_GROUP_SOUND
+  sta API_COMMAND
+
+
+end:
+  jmp end ; infinite loop

--- a/examples/assembly/neo6502.asm.inc
+++ b/examples/assembly/neo6502.asm.inc
@@ -18,31 +18,430 @@ SendMessage    = $FFF7
 ;--------------------------------------;
 
 ControlPort = $FF00
-DCommand    = ControlPort + 0 ; function group address
-DFunction   = ControlPort + 1 ; function address
-DParameters = ControlPort + 4 ; function parameters base address (+0-7)
+API_COMMAND    = ControlPort + 0 ; function group address
+API_FUNCTION   = ControlPort + 1 ; function address
+API_ERROR      = ControlPort + 2 ; function error codes
+API_STATUS     = ControlPort + 3 ; misc hardware status codes (bit-field)
+API_PARAMETERS = ControlPort + 4 ; function parameters base address (+0-7)
 
 
-;------------------------------------------------------------------;
-; Neo6502 Kernel API control codes (see documents/release/api.pdf) ;
-;------------------------------------------------------------------;
+;------------------------------------------------;
+; Neo6502 Kernel API control codes (see api.pdf) ;
+;------------------------------------------------;
+
+; Status Information
+API_ERROR_NONE = #$00 ; error code
+API_STATUS_ESC = #$07 ; flag
+
+; System functions (Group 1)
+API_GROUP_SYSTEM     = #$01 ; API function group
+API_FN_TIMER         = #$01 ; API function
+API_FN_KEY_STATUS    = #$02 ; API function
+API_FN_BASIC         = #$03 ; API function
+API_FN_CREDITS       = #$04 ; API function
+API_FN_SERIAL_STATUS = #$05 ; API function
+API_FN_LOCALE        = #$06 ; API function
+API_FN_RESET         = #$07 ; API function
 
 ; Console functions (Group 2)
-API_GROUP_CONSOLE = #$02 ; API function group ID
-API_FN_WRITE_CHAR = #$06 ; API function ID
-API_FN_CURSOR_POS = #$07 ; API function ID
+API_GROUP_CONSOLE     = #$02 ; API function group
+API_FN_READ_CHAR      = #$01 ; API function
+API_FN_CONSOLE_STATUS = #$02 ; API function
+API_FN_READ_LINE      = #$03 ; API function
+API_FN_DEFINE_HOTKEY  = #$04 ; API function
+API_FN_DEFINE_CHAR    = #$05 ; API function
+API_FN_WRITE_CHAR     = #$06 ; API function
+API_FN_CURSOR_POS     = #$07 ; API function
+API_FN_LIST_HOTKEYS   = #$08 ; API function
+API_FN_SET_CURSOR_POS = #$07 ; API function
+API_FN_LIST_HOTKEYS   = #$08 ; API function
+API_FN_SCREEN_SIZE    = #$09 ; API function
+API_FN_INSERT_LINE    = #$0A ; API function
+API_FN_DELETE_LINE    = #$0B ; API function
+API_FN_CLEAR_SCREEN   = #$0C ; API function
+API_FN_CURSOR_POS     = #$0D ; API function
+API_FN_CLEAR_REGIION  = #$0E ; API function
+API_FN_SET_TEXT_COLOR = #$0F ; API function
+API_FN_CURSOR_INVERSE = #$10 ; API function
+
+; Console results (Group 2 Function 2)
+API_QUEUE_EMPTY = #$FF ; API result (status code)
+
+; File I/O functions (Group 3)
+API_GROUP_FILEIO      = #$03 ; API function group
+API_FN_LIST_DIRECTORY = #$01 ; API function
+API_FN_LOAD_FILENAME  = #$02 ; API function
+API_FN_STORE_FILENAME = #$03 ; API function
+API_FN_FILE_OPEN      = #$04 ; API function
+API_FN_FILE_CLOSE     = #$05 ; API function
+API_FN_FILE_SEEK      = #$06 ; API function
+API_FN_FILE_TELL      = #$07 ; API function
+API_FN_FILE_READ      = #$08 ; API function
+API_FN_FILE_WRITE     = #$09 ; API function
+API_FN_FILE_SIZE      = #$0A ; API function
+API_FN_FILE_SET_SIZE  = #$0B ; API function
+API_FN_FILE_RENAME    = #$0C ; API function
+API_FN_FILE_DELETE    = #$0D ; API function
+API_FN_DIR_CHDIR      = #$0E ; API function
+API_FN_DIR_MKDIR      = #$0F ; API function
+API_FN_FILE_STAT      = #$10 ; API function
+API_FN_DIR_OPEN       = #$11 ; API function
+API_FN_DIR_READ       = #$12 ; API function
+API_FN_DIR_CLOSE      = #$13 ; API function
+API_FN_FILE_COPY      = #$14 ; API function
+API_FN_LIST_FILTERED  = #$20 ; API function
+
+; File I/O parameters (Group 3 Function 2)
+API_FILE_TO_SCREEN = #$FFFF ; API parameter
+
+; Mathematics functions (Group 4)
+API_GROUP_MATH    = #$04 ; API function group
+API_FN_ADD        = #$00 ; API function
+API_FN_SUB        = #$01 ; API function
+API_FN_MUL        = #$02 ; API function
+API_FN_DIV_DEC    = #$03 ; API function
+API_FN_DIV_INT    = #$04 ; API function
+API_FN_MOD        = #$05 ; API function
+API_FN_COMP       = #$06 ; API function
+API_FN_NEG        = #$10 ; API function
+API_FN_FLOOR      = #$11 ; API function
+API_FN_SQRT       = #$12 ; API function
+API_FN_SINE       = #$13 ; API function
+API_FN_COS        = #$14 ; API function
+API_FN_TAN        = #$15 ; API function
+API_FN_ATAN       = #$16 ; API function
+API_FN_EXP        = #$17 ; API function
+API_FN_LOG        = #$18 ; API function
+API_FN_ABS        = #$19 ; API function
+API_FN_SIGN       = #$1A ; API function
+API_FN_RND_DEC    = #$1B ; API function
+API_FN_RND_INT    = #$1C ; API function
+API_FN_INT_TO_DEC = #$20 ; API function
+API_FN_STR_TO_NUM = #$21 ; API function
+API_FN_NUM_TO_STR = #$22 ; API function
+
+; Graphics functions (Group 5)
+API_GROUP_GRAPHICS     = #$05 ; API function group
+API_FN_SET_GFX         = #$01 ; API function
+API_FN_DRAW_LINE       = #$02 ; API function
+API_FN_DRAW_RECT       = #$03 ; API function
+API_FN_DRAW_ELIPSE     = #$04 ; API function
+API_FN_DRAW_PIXEL      = #$05 ; API function
+API_FN_DRAW_TEXT       = #$06 ; API function
+API_FN_DRAW_IMG        = #$07 ; API function
+API_FN_DRAW_TILEMAP    = #$08 ; API function
+API_FN_SET_PALETTE     = #$20 ; API function
+API_FN_READ_PIXEL      = #$21 ; API function
+API_FN_RESET_PALETTE   = #$22 ; API function
+API_FN_SET_TILEMAP     = #$23 ; API function
+API_FN_READ_SPRITE_PXL = #$24 ; API function
+API_FN_FRAME_COUNT     = #$25 ; API function
+API_FN_SET_COLOR       = #$40 ; API function
+API_FN_SET_SOLID       = #$41 ; API function
+API_FN_SET_DRAW_SIZE   = #$42 ; API function
+API_FN_SET_FLIP        = #$43 ; API function
+
+; Graphics parameters (Group 5, Function 1 - Group 6, Function 2)
+API_FLIP_HORZ = #$00 ; API parameter (flag)
+API_FLIP_VERT = #$01 ; API parameter (flag)
+
+; Graphics results (Group 5, Functions 33,36)
+API_PIXEL_TRANSPARENT = #$00 ; API result (flag)
+
+; Sprites functions (Group 6)
+API_GROUP_SPRITES       = #$06 ; API function group
+API_FN_SPRITE_RESET     = #$01 ; API function
+API_FN_SPRITE_SET       = #$02 ; API function
+API_FN_SPRITE_HIDE      = #$03 ; API function
+API_FN_SPRITE_COLLISION = #$04 ; API function
+API_FN_SPRITE_POS       = #$05 ; API function
+
+; Sprites parameters (Group 6, Function 2)
+API_SPRITE_TURTLE = #$00 ; API parameter (sprite index)
+API_SPRITE_32BIT  = #$40 ; API parameter (bit-mask)
+API_SPRITE_CLEAR  = #$80 ; API parameter (bit-mask)
+API_ANCHOR_BL     = #$01 ; API parameter (anchor position)
+API_ANCHOR_B      = #$02 ; API parameter (anchor position)
+API_ANCHOR_BR     = #$03 ; API parameter (anchor position)
+API_ANCHOR_L      = #$04 ; API parameter (anchor position)
+API_ANCHOR_C      = #$05 ; API parameter (anchor position)
+API_ANCHOR_R      = #$06 ; API parameter (anchor position)
+API_ANCHOR_TL     = #$07 ; API parameter (anchor position)
+API_ANCHOR_T      = #$08 ; API parameter (anchor position)
+API_ANCHOR_TR     = #$09 ; API parameter (anchor position)
+
+; Sprites results (Group 6, Function 4)
+API_COLLISION_NONE = #$00 ; API result (flag)
+
+; Controller functions (Group 7)
+API_GROUP_CONTROLLER   = #$07 ; API function group
+API_FN_READ_CONTROLLER = #$01 ; API function
+
+; Controller results (Group 7, Function 1)
+API_CONTROLLER_LEFT  = #$01 ; API result (status bit-mask)
+API_CONTROLLER_RIGHT = #$02 ; API result (status bit-mask)
+API_CONTROLLER_UP    = #$04 ; API result (status bit-mask)
+API_CONTROLLER_DOWN  = #$08 ; API result (status bit-mask)
+API_CONTROLLER_BTNA  = #$10 ; API result (status bit-mask)
+API_CONTROLLER_BTNB  = #$20 ; API result (status bit-mask)
 
 ; Sound functions (Group 8)
-API_GROUP_SOUND     = #$08 ; API function group ID
-API_FN_BEEP         = #$03 ; API function ID
-API_FN_PLAY_SOUND   = #$05 ; API function ID
-API_SOUND_CH_00     = #$00 ; API function parameter ID (only 0 by default)
-API_SOUND_EFFECT_06 = #$06 ; API function parameter ID (currently 00-17 hex)
+API_GROUP_SOUND      = #$08 ; API function group
+API_FN_RESET_SOUND   = #$01 ; API function
+API_FN_RESET_CHANNEL = #$02 ; API function
+API_FN_BEEP          = #$03 ; API function
+API_FN_QUEUE_SOUND   = #$04 ; API function
+API_FN_PLAY_SOUND    = #$05 ; API function
+API_FN_SOUND_STATUS  = #$06 ; API function
+
+; Sound parameters (Group 8, Functions 2,4,5)
+API_SOUND_CH_00 = #$00 ; API parameter (channel index)
+
+; Sound parameters (Group 8, Function 4)
+API_NOTE_REST      = #$0000 ; API parameter (musical rest)
+API_NOTE_C0        = #$0010 ; API parameter (musical note)
+API_NOTE_Cs0       = #$0011 ; API parameter (musical note)
+API_NOTE_Df0       = #$0011 ; API parameter (musical note)
+API_NOTE_D0        = #$0012 ; API parameter (musical note)
+API_NOTE_Ds0       = #$0013 ; API parameter (musical note)
+API_NOTE_Ef0       = #$0013 ; API parameter (musical note)
+API_NOTE_E0        = #$0015 ; API parameter (musical note)
+API_NOTE_F0        = #$0016 ; API parameter (musical note)
+API_NOTE_Fs0       = #$0017 ; API parameter (musical note)
+API_NOTE_Gf0       = #$0017 ; API parameter (musical note)
+API_NOTE_G0        = #$0018 ; API parameter (musical note)
+API_NOTE_Af0       = #$001A ; API parameter (musical note)
+API_NOTE_Gs0       = #$001A ; API parameter (musical note)
+API_NOTE_A0        = #$001C ; API parameter (musical note)
+API_NOTE_As0       = #$001D ; API parameter (musical note)
+API_NOTE_Bf0       = #$001D ; API parameter (musical note)
+API_NOTE_B0        = #$001F ; API parameter (musical note)
+API_NOTE_C1        = #$0021 ; API parameter (musical note)
+API_NOTE_Cs1       = #$0023 ; API parameter (musical note)
+API_NOTE_Df1       = #$0023 ; API parameter (musical note)
+API_NOTE_D1        = #$0025 ; API parameter (musical note)
+API_NOTE_Ds1       = #$0027 ; API parameter (musical note)
+API_NOTE_Ef1       = #$0027 ; API parameter (musical note)
+API_NOTE_E1        = #$0029 ; API parameter (musical note)
+API_NOTE_F1        = #$002C ; API parameter (musical note)
+API_NOTE_Fs1       = #$002E ; API parameter (musical note)
+API_NOTE_Gf1       = #$002E ; API parameter (musical note)
+API_NOTE_G1        = #$0031 ; API parameter (musical note)
+API_NOTE_Af1       = #$0034 ; API parameter (musical note)
+API_NOTE_Gs1       = #$0034 ; API parameter (musical note)
+API_NOTE_A1        = #$0037 ; API parameter (musical note)
+API_NOTE_As1       = #$003A ; API parameter (musical note)
+API_NOTE_Bf1       = #$003A ; API parameter (musical note)
+API_NOTE_B1        = #$003E ; API parameter (musical note)
+API_NOTE_C2        = #$0041 ; API parameter (musical note)
+API_NOTE_Cs2       = #$0045 ; API parameter (musical note)
+API_NOTE_Df2       = #$0045 ; API parameter (musical note)
+API_NOTE_D2        = #$0049 ; API parameter (musical note)
+API_NOTE_Ds2       = #$004E ; API parameter (musical note)
+API_NOTE_Ef2       = #$004E ; API parameter (musical note)
+API_NOTE_E2        = #$0052 ; API parameter (musical note)
+API_NOTE_F2        = #$0057 ; API parameter (musical note)
+API_NOTE_Fs2       = #$005C ; API parameter (musical note)
+API_NOTE_Gf2       = #$005C ; API parameter (musical note)
+API_NOTE_G2        = #$0062 ; API parameter (musical note)
+API_NOTE_Af2       = #$0068 ; API parameter (musical note)
+API_NOTE_Gs2       = #$0068 ; API parameter (musical note)
+API_NOTE_A2        = #$006E ; API parameter (musical note)
+API_NOTE_As2       = #$0075 ; API parameter (musical note)
+API_NOTE_Bf2       = #$0075 ; API parameter (musical note)
+API_NOTE_B2        = #$007B ; API parameter (musical note)
+API_NOTE_C3        = #$0083 ; API parameter (musical note)
+API_NOTE_Cs3       = #$008B ; API parameter (musical note)
+API_NOTE_Df3       = #$008B ; API parameter (musical note)
+API_NOTE_D3        = #$0093 ; API parameter (musical note)
+API_NOTE_Ds3       = #$009C ; API parameter (musical note)
+API_NOTE_Ef3       = #$009C ; API parameter (musical note)
+API_NOTE_E3        = #$00A5 ; API parameter (musical note)
+API_NOTE_F3        = #$00AF ; API parameter (musical note)
+API_NOTE_Fs3       = #$00B9 ; API parameter (musical note)
+API_NOTE_Gf3       = #$00B9 ; API parameter (musical note)
+API_NOTE_G3        = #$00C4 ; API parameter (musical note)
+API_NOTE_Af3       = #$00D0 ; API parameter (musical note)
+API_NOTE_Gs3       = #$00D0 ; API parameter (musical note)
+API_NOTE_A3        = #$00DC ; API parameter (musical note)
+API_NOTE_As3       = #$00E9 ; API parameter (musical note)
+API_NOTE_Bf3       = #$00E9 ; API parameter (musical note)
+API_NOTE_B3        = #$00F7 ; API parameter (musical note)
+API_NOTE_C4        = #$0106 ; API parameter (musical note)
+API_NOTE_Cs4       = #$0115 ; API parameter (musical note)
+API_NOTE_Df4       = #$0115 ; API parameter (musical note)
+API_NOTE_D4        = #$0126 ; API parameter (musical note)
+API_NOTE_Ds4       = #$0137 ; API parameter (musical note)
+API_NOTE_Ef4       = #$0137 ; API parameter (musical note)
+API_NOTE_E4        = #$014A ; API parameter (musical note)
+API_NOTE_F4        = #$015D ; API parameter (musical note)
+API_NOTE_Fs4       = #$0172 ; API parameter (musical note)
+API_NOTE_Gf4       = #$0172 ; API parameter (musical note)
+API_NOTE_G4        = #$0188 ; API parameter (musical note)
+API_NOTE_Af4       = #$019F ; API parameter (musical note)
+API_NOTE_Gs4       = #$019F ; API parameter (musical note)
+API_NOTE_A4        = #$01B8 ; API parameter (musical note)
+API_NOTE_As4       = #$01D2 ; API parameter (musical note)
+API_NOTE_Bf4       = #$01D2 ; API parameter (musical note)
+API_NOTE_B4        = #$01EE ; API parameter (musical note)
+API_NOTE_C5        = #$020B ; API parameter (musical note)
+API_NOTE_Cs5       = #$022A ; API parameter (musical note)
+API_NOTE_Df5       = #$022A ; API parameter (musical note)
+API_NOTE_D5        = #$024B ; API parameter (musical note)
+API_NOTE_Ds5       = #$026E ; API parameter (musical note)
+API_NOTE_Ef5       = #$026E ; API parameter (musical note)
+API_NOTE_E5        = #$0293 ; API parameter (musical note)
+API_NOTE_F5        = #$02BA ; API parameter (musical note)
+API_NOTE_Fs5       = #$02E4 ; API parameter (musical note)
+API_NOTE_Gf5       = #$02E4 ; API parameter (musical note)
+API_NOTE_G5        = #$0310 ; API parameter (musical note)
+API_NOTE_Af5       = #$033F ; API parameter (musical note)
+API_NOTE_Gs5       = #$033F ; API parameter (musical note)
+API_NOTE_A5        = #$0370 ; API parameter (musical note)
+API_NOTE_As5       = #$03A4 ; API parameter (musical note)
+API_NOTE_Bf5       = #$03A4 ; API parameter (musical note)
+API_NOTE_B5        = #$03DC ; API parameter (musical note)
+API_NOTE_C6        = #$0417 ; API parameter (musical note)
+API_NOTE_Cs6       = #$0455 ; API parameter (musical note)
+API_NOTE_Df6       = #$0455 ; API parameter (musical note)
+API_NOTE_D6        = #$0497 ; API parameter (musical note)
+API_NOTE_Ds6       = #$04DD ; API parameter (musical note)
+API_NOTE_Ef6       = #$04DD ; API parameter (musical note)
+API_NOTE_E6        = #$0527 ; API parameter (musical note)
+API_NOTE_F6        = #$0575 ; API parameter (musical note)
+API_NOTE_Fs6       = #$05C8 ; API parameter (musical note)
+API_NOTE_Gf6       = #$05C8 ; API parameter (musical note)
+API_NOTE_G6        = #$0620 ; API parameter (musical note)
+API_NOTE_Af6       = #$067D ; API parameter (musical note)
+API_NOTE_Gs6       = #$067D ; API parameter (musical note)
+API_NOTE_A6        = #$06E0 ; API parameter (musical note)
+API_NOTE_As6       = #$0749 ; API parameter (musical note)
+API_NOTE_Bf6       = #$0749 ; API parameter (musical note)
+API_NOTE_B6        = #$07B8 ; API parameter (musical note)
+API_NOTE_C7        = #$082D ; API parameter (musical note)
+API_NOTE_Cs7       = #$08A9 ; API parameter (musical note)
+API_NOTE_Df7       = #$08A9 ; API parameter (musical note)
+API_NOTE_D7        = #$092D ; API parameter (musical note)
+API_NOTE_Ds7       = #$09B9 ; API parameter (musical note)
+API_NOTE_Ef7       = #$09B9 ; API parameter (musical note)
+API_NOTE_E7        = #$0A4D ; API parameter (musical note)
+API_NOTE_F7        = #$0AEA ; API parameter (musical note)
+API_NOTE_Fs7       = #$0B90 ; API parameter (musical note)
+API_NOTE_Gf7       = #$0B90 ; API parameter (musical note)
+API_NOTE_G7        = #$0C40 ; API parameter (musical note)
+API_NOTE_Af7       = #$0CFA ; API parameter (musical note)
+API_NOTE_Gs7       = #$0CFA ; API parameter (musical note)
+API_NOTE_A7        = #$0DC0 ; API parameter (musical note)
+API_NOTE_As7       = #$0E91 ; API parameter (musical note)
+API_NOTE_Bf7       = #$0E91 ; API parameter (musical note)
+API_NOTE_B7        = #$0F6F ; API parameter (musical note)
+API_NOTE_C8        = #$105A ; API parameter (musical note)
+API_NOTE_Cs8       = #$1153 ; API parameter (musical note)
+API_NOTE_Df8       = #$1153 ; API parameter (musical note)
+API_NOTE_D8        = #$125B ; API parameter (musical note)
+API_NOTE_Ds8       = #$1372 ; API parameter (musical note)
+API_NOTE_Ef8       = #$1372 ; API parameter (musical note)
+API_NOTE_E8        = #$149A ; API parameter (musical note)
+API_NOTE_F8        = #$15D4 ; API parameter (musical note)
+API_NOTE_Fs8       = #$1720 ; API parameter (musical note)
+API_NOTE_Gf8       = #$1720 ; API parameter (musical note)
+API_NOTE_G8        = #$1880 ; API parameter (musical note)
+API_NOTE_Af8       = #$19F5 ; API parameter (musical note)
+API_NOTE_Gs8       = #$19F5 ; API parameter (musical note)
+API_NOTE_A8        = #$1B80 ; API parameter (musical note)
+API_NOTE_As8       = #$1D23 ; API parameter (musical note)
+API_NOTE_Bf8       = #$1D23 ; API parameter (musical note)
+API_NOTE_B8        = #$1EDE ; API parameter (musical note)
+API_NOTE_C9        = #$20B4 ; API parameter (musical note)
+API_NOTE_Cs9       = #$22A6 ; API parameter (musical note)
+API_NOTE_Df9       = #$22A6 ; API parameter (musical note)
+API_NOTE_D9        = #$24B5 ; API parameter (musical note)
+API_NOTE_Ds9       = #$26E4 ; API parameter (musical note)
+API_NOTE_Ef9       = #$26E4 ; API parameter (musical note)
+API_NOTE_E9        = #$2934 ; API parameter (musical note)
+API_NOTE_F9        = #$2BA7 ; API parameter (musical note)
+API_NOTE_Fs9       = #$2E40 ; API parameter (musical note)
+API_NOTE_Gf9       = #$2E40 ; API parameter (musical note)
+API_NOTE_G9        = #$3100 ; API parameter (musical note)
+API_NOTE_Af9       = #$33EA ; API parameter (musical note)
+API_NOTE_Gs9       = #$33EA ; API parameter (musical note)
+API_NOTE_A9        = #$3700 ; API parameter (musical note)
+API_NOTE_As9       = #$3A45 ; API parameter (musical note)
+API_NOTE_Bf9       = #$3A45 ; API parameter (musical note)
+API_NOTE_B9        = #$3DBC ; API parameter (musical note)
+API_NOTE_C10       = #$4168 ; API parameter (musical note)
+API_NOTE_Cs10      = #$454C ; API parameter (musical note)
+API_NOTE_Df10      = #$454C ; API parameter (musical note)
+API_NOTE_D10       = #$496B ; API parameter (musical note)
+API_NOTE_Ds10      = #$4DC8 ; API parameter (musical note)
+API_NOTE_Ef10      = #$4DC8 ; API parameter (musical note)
+API_TEMPO_60       = #$0064 ; API parameter (musical note duration, 60BPM)
+API_TEMPO_80       = #$004B ; API parameter (musical note duration, 80BPM)
+API_TEMPO_90       = #$0042 ; API parameter (musical note duration, 90BPM)
+API_TEMPO_120      = #$0032 ; API parameter (musical note duration, 120BPM)
+API_SLIDE_NONE     = #$0000 ; API parameter (slide value)
+API_SLIDE_SLOW     = #$0004 ; API parameter (slide range)
+API_SLIDE_MED      = #$0008 ; API parameter (slide range)
+API_SLIDE_FAST     = #$0010 ; API parameter (slide range)
+API_SOUND_SRC_BEEP = #$00   ; API parameter (sound generator)
+
+; Sound parameters (Group 8, Function 5)
+API_SFX_POSITIVE     = #$00 ; API parameter (sound effect)
+API_SFX_NEGATIVE     = #$01 ; API parameter (sound effect)
+API_SFX_ERROR        = #$02 ; API parameter (sound effect)
+API_SFX_CONFIRM      = #$03 ; API parameter (sound effect)
+API_SFX_REJECT       = #$04 ; API parameter (sound effect)
+API_SFX_SWEEP        = #$05 ; API parameter (sound effect)
+API_SFX_COIN         = #$06 ; API parameter (sound effect)
+API_SFX_LASER_LONG   = #$07 ; API parameter (sound effect)
+API_SFX_POWERUP      = #$08 ; API parameter (sound effect)
+API_SFX_VICTORY      = #$09 ; API parameter (sound effect)
+API_SFX_DEFEAT       = #$0A ; API parameter (sound effect)
+API_SFX_FANFARE      = #$0B ; API parameter (sound effect)
+API_SFX_ALARM1       = #$0C ; API parameter (sound effect)
+API_SFX_ALARM2       = #$0D ; API parameter (sound effect)
+API_SFX_ALARM3       = #$0E ; API parameter (sound effect)
+API_SFX_RING1        = #$0F ; API parameter (sound effect)
+API_SFX_RING2        = #$10 ; API parameter (sound effect)
+API_SFX_RING3        = #$11 ; API parameter (sound effect)
+API_SFX_DANGER       = #$12 ; API parameter (sound effect)
+API_SFX_EXPL_LONG    = #$13 ; API parameter (sound effect)
+API_SFX_EXPL_MEDIUM  = #$14 ; API parameter (sound effect)
+API_SFX_EXPL_SHORT   = #$15 ; API parameter (sound effect)
+API_SFX_LASER_MEDIUM = #$16 ; API parameter (sound effect)
+API_SFX_LASER_SHORT  = #$17 ; API parameter (sound effect)
+
+; Turtle Graphics functions (Group 9)
+API_GROUP_TURTLE   = #$09 ; API function group
+API_FN_TURTLE_INIT = #$01 ; API function
+API_FN_TURTLE_TURN = #$02 ; API function
+API_FN_TURTLE_MOVE = #$03 ; API function
+API_FN_TURTLE_HIDE = #$04 ; API function
+API_FN_TURTLE_HOME = #$05 ; API function
+
+; Turtle Graphics parameters (Group 9, Function 2)
+API_TURTLE_LEFT  = #$010E ; API parameter (turn -90 degrees)
+API_TURTLE_RIGHT = #$005A ; API parameter (turn +90 degrees)
+API_TURTLE_FLIP  = #$00B4 ; API parameter (turn 180 degrees)
+
+; Turtle Graphics parameters (Group 9, Function 3)
+API_PEN_UP   = #$00 ; API parameter (turtle tracks on)
+API_PEN_DOWN = #$01 ; API parameter (turtle tracks off)
+
+; UExt functions (Group 10)
+API_GROUP_UEXT      = #$09 ; API function group
+API_FN_UEXT_INIT    = #$01 ; API function
+API_FN_GPIO_WRITE   = #$02 ; API function
+API_FN_GPIO_READ    = #$03 ; API function
+API_FN_SET_PORT_DIR = #$04 ; API function
+API_FN_I2C_WRITE    = #$05 ; API function
+API_FN_I2C_READ     = #$06 ; API function
+API_FN_ANALOG_READ  = #$07 ; API function
 
 
-;--------------------------;
-; color control characters ;
-;--------------------------;
+;--------;
+; colors ;
+;--------;
 
 COLOR_BLACK       = #$80
 COLOR_RED         = #$81


### PR DESCRIPTION
this adds two examples, one demonstrating sounds, one demonstrating graphics; and completes the set of assembly macros for the API functions ~~(complete up to last week - more are needed now)~~(DONE) = the same could be done for the C header; but there may be memory concerns (not sure how cc65 works) - they could be translated into macros though