### PR TITLE
Update the documentation for the file I/O calls.

### DIFF
--- a/documents/release/source/api.tex
+++ b/documents/release/source/api.tex
@@ -12,6 +12,8 @@
 \usepackage{makecell}
 \usepackage{multirow}
 \usepackage{tabularx}
+\usepackage{longtable}
+\usepackage{caption}
 \usepackage{wrapfig}
 
 \renewcommand{\familydefault}{\sfdefault}
@@ -20,7 +22,7 @@
 
 \title{Neo6502 Assembly - Messaging API}
 \author{Paul Robson \\ Bill Auger}
-\date{2024-02-29}
+\date{2024-03-01}
 
 \graphicspath{ {./img/}                             % WRT local editor (eg: texworks)
                {./documents/release/source/img/}    % WRT command line
@@ -302,12 +304,17 @@ and common parameters (colors, musical notes, etc).
 
 
 % makedispatch: BEGIN
-\begin{table}[h]
-\centering\textbf{Group 1 - System Functions}
-\begin{tabular}{ | c | l | p{12cm} | }
+\begin{longtable*}{ | c | l | p{12cm} | }
+\caption*{Group 1 - System Functions} \\
 \hline
 \textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
 \hline
+\endfirsthead
+\caption*{Group 1 - System Functions (continued)} \\
+\hline
+\textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
+\hline
+\endhead
 \ApiFnRow{0}{Reset}{
 Resets the messaging system and component systems.
 Normally, should not be used.
@@ -341,19 +348,19 @@ For example:
 System Reset. This is a full hardware reset. It resets the RP2040 using the Watchdog timer, and
 this also resets the 65C02.
 }
-\end{tabular}
-\end{table}
-
-
+\end{longtable*}
 \pagebreak
-
-
-\begin{table}[h]
-\centering\textbf{Group 2 - Console Functions}
-\begin{tabular}{ | c | l | p{12cm} | }
+\begin{longtable*}{ | c | l | p{12cm} | }
+\caption*{Group 2 - Console Functions} \\
 \hline
 \textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
 \hline
+\endfirsthead
+\caption*{Group 2 - Console Functions (continued)} \\
+\hline
+\textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
+\hline
+\endhead
 \ApiFnRow{0}{Write Character}{
 Function 0 is console out (duplicate of Function 6 for backward compatibility).
 }
@@ -394,19 +401,6 @@ Refer to Section \#\ref{console-codes} "Console Codes" for details.
 \ApiFnRow{7}{Set Cursor Pos}{
 Move the cursor to the screen character cell \Param{0}\textless-X, \Param{1}\textless-Y.
 }
-\end{tabular}
-\end{table}
-
-
-\pagebreak
-
-
-\begin{table}[h]
-\centering\textbf{Group 2 - Console Functions (continued)}
-\begin{tabular}{ | c | l | p{12cm} | }
-\hline
-\textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
-\hline
 \ApiFnRow{8}{List Hotkeys}{
 Display the current function key definitions.
 }
@@ -440,134 +434,250 @@ Set Text Color
 Toggles the cursor colour between normal and inverse
 (ie: swaps FG and BG colors). This should not be used.
 }
-\end{tabular}
-\end{table}
-
-
+\end{longtable*}
 \pagebreak
-
-
-\begin{table}[h]
-\centering\textbf{Group 3 - File I/O Functions}
-\begin{tabular}{ | c | l | p{12cm} | }
+\begin{longtable*}{ | c | l | p{12cm} | }
+\caption*{Group 3 - File I/O Functions} \\
 \hline
 \textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
 \hline
+\endfirsthead
+\caption*{Group 3 - File I/O Functions (continued)} \\
+\hline
+\textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
+\hline
+\endhead
 \ApiFnRow{1}{List Directory}{
 Display the file listing of the present directory.
 }
 \ApiFnRow{2}{Load File}{
-Load a file by name, per the length-prefixed string stored at the memory location
-specified in \Param{0,1} into to the memory location specified in \Param{2,3}.
-When the command completes, an error/status code will be in \Param{0}.
-If the address in \Param{2,3} is \MonoSp{\$FFFF}, the file will be loaded into the
+Load a file by name into memory. On input:
+\begin{itemize}
+\item \Param{0,1} points to the length-prefixed filename string;
+\item \Param{2,3} contains the location to write the data to. If the
+address is \MonoSp{\$FFFF}, the file will instead be loaded into the
 graphics working memory, used for sprites, tiles, images.
+\end{itemize}
+On output:
+\begin{itemize}
+\item \Param{0} contains an error/status code.
+\end{itemize}
 }
 \ApiFnRow{3}{Store File}{
-Save the data stored at the memory location specified in \Param{2,3} to storage,
-as a file with the specified filename, per the length-prefixed string
-stored at the memory location specified in \Param{0,1}.
-\Param{4,5} specify the number of bytes to store.
-When the command completes, an error/status code will be in \Param{0}.
+Saves data in memory to a file. On input:
+\begin{itemize}
+\item \Param{0,1} points to the length-prefixed filename string;
+\item \Param{2,3} contains the location to read data from;
+\item \Param{4,5} specified the number of bytes to styore.
+\end{itemize}
+On output:
+\begin{itemize}
+\item \Param{0} contains an error/status code.
+\end{itemize}
 }
 \ApiFnRow{4}{File Open}{
-File Open
-\newline TODO: explain this function and any parameters
+Opens a file into a specific channel. On input:
+\begin{itemize}
+\item \Param{0} contains the file channel to open;
+\item \Param{1,2} contains the length-prefixed filename;
+\item \Param{3} contains the open mode. See below.
+\end{itemize}
+Valid open modes are:
+\begin{itemize}
+\item 0 opens the file for read-only access;
+\item 1 opens the file for write-only access;
+\item 2 opens the file for read-write access;
+\item 3 creates the file if it doesn't already exist, truncates it if it
+does, and opens the file for read-write access.
+\end{itemize}
+Modes 0 to 2 will fail if the file does not already exist. If the
+channel is already open, the call fails. Opening the same file more than
+once on different channels has undefined behaviour and is not
+recommended.
 }
 \ApiFnRow{5}{File Close}{
-File Close
-\newline TODO: explain this function and any parameters
+Closes a particular channel. On input:
+\begin{itemize}
+\item \Param{0} contains the file channel to close.
+\end{itemize}
 }
 \ApiFnRow{6}{File Seek}{
-File Seek
-\newline TODO: explain this function and any parameters
+Seeks the file opened on a particular channel to a location. On input:
+\begin{itemize}
+\item \Param{0} contains the file channel to operate on;
+\item \Param{1,2,3,4} contains the file location.
+\end{itemize}
+You can seek beyond the end of a file to extend the file. Whether the
+file size changes when the seek happens or when you perform the write is
+undefined.
 }
 \ApiFnRow{7}{File Tell}{
-Deposits the current seek position (byte-offset) into \Param{4}.
+Returns the current seek location for the file opened on a particular channel. On input:
+\begin{itemize}
+\item \Param{0} contains the file channel to operate on.
+\end{itemize}
+On output:
+\begin{itemize}
+\item \Param{1,2,3,4} contains the file location.
+\end{itemize}
 }
 \ApiFnRow{8}{File Read}{
-File Read
-\newline TODO: explain this function and any parameters
+Reads data from an opened file. On input:
+\begin{itemize}
+\item \Param{0} contains the file channel to operate on;
+\item \Param{1,2} points to the destination in memory, or \MonoSp{\$FFFF}
+to write to graphics memory;
+\item \Param{2,3} contains the amount of data to read.
+\end{itemize}
+On output:
+\begin{itemize}
+\item \Param{2,3} is updated to contain the amount of data actually read.
+\end{itemize}
+Data is read from the current seek position, which is advanced after the
+read.
 }
-\end{tabular}
-\end{table}
-
-
-\pagebreak
-
-
-\begin{table}[h]
-\centering\textbf{Group 3 - File I/O Functions (continued)}
-\begin{tabular}{ | c | l | p{12cm} | }
-\hline
-\textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
-\hline
 \ApiFnRow{9}{File Write}{
-File Write
-\newline TODO: explain this function and any parameters
+Writes data to an opened file. On input:
+\begin{itemize}
+\item \Param{0} contains the file channel to operate on;
+\item \Param{1,2} points to the data in memory;
+\item \Param{2,3} contains the amount of data to write.
+\end{itemize}
+On output:
+\begin{itemize}
+\item \Param{2,3} is updated to contain the amount of data actually written.
+\end{itemize}
+Data is written to the current seek position, which is advanced after the
+write.
 }
 \ApiFnRow{10}{File Size}{
-File Size
-\newline TODO: explain this function and any parameters
+Returns the current size of an opened file. On input:
+\begin{itemize}
+\item \Param{0} contains the file channel to operate on.
+\end{itemize}
+On output:
+\begin{itemize}
+\item \Param{1,2,3,4} contains the size of the file.
+\end{itemize}
+This call should be used on open files and takes into account any
+buffered data which has not yet been written to disk. As a result it may
+return a different size to the stat API call described below.
 }
 \ApiFnRow{11}{File Set Size}{
-File Set Size
-\newline TODO: explain this function and any parameters
+Extends or truncates an opened file to a particular size. On input:
+\begin{itemize}
+\item \Param{0} contains the file channel to operate on;
+\item \Param{1,2,3,4} contains the new size of the file.
+\end{itemize}
 }
 \ApiFnRow{12}{File Rename}{
-File Rename
-\newline TODO: explain this function and any parameters
+Renames a file. On input:
+\begin{itemize}
+\item \Param{0,1} points to the length-prefixed string for the old name;
+\item \Param{2,3} points to the length-prefixed string for the new name.
+\end{itemize}
+Files may be renamed across directories.
 }
 \ApiFnRow{13}{Delete File}{
-Delete File
-\newline TODO: explain this function and any parameters
+Deletes a file or directory. On input:
+\begin{itemize}
+\item \Param{0,1} points to the length-prefixed filename string.
+\end{itemize}
+Deleting a file which is open has undefined behaviour. Directories may
+only be deleted if they are empty.
 }
 \ApiFnRow{14}{Create Directory}{
-Create Directory
-\newline TODO: explain this function and any parameters
+Creates a new directory. On input:
+\begin{itemize}
+\item \Param{0,1} points to the length-prefixed filename string.
+\end{itemize}
 }
 \ApiFnRow{15}{Change Directory}{
-Change Directory
-\newline TODO: explain this function and any parameters
+Changes the current working directory. On input:
+\begin{itemize}
+\item \Param{0,1} points to the length-prefixed path string.
+\end{itemize}
 }
 \ApiFnRow{16}{Stat File}{
-Stat File
-\newline TODO: explain this function and any parameters
+Retrieves information about a file by name. On input:
+\begin{itemize}
+\item \Param{0,1} points to the length-prefixed filename string.
+\end{itemize}
+On output:
+\begin{itemize}
+\item \Param{0,1,2,3} contains the length of the file;
+\item \Param{4} contains the attribute bitfield of the file.
+\end{itemize}
+If the file is open for writing, this may not return the correct size
+due to buffered data not having been flushed to disk.
+File attributes are a bitfield as follows:
+\newline
+
+\ParamBits{File attributes}
+{0}
+{0}
+{0}
+{Hidden}
+{Read only}
+{Archive}
+{System}
+{Directory}
 }
 \ApiFnRow{17}{Open Directory}{
-Open Directory
-\newline TODO: explain this function and any parameters
+Opens a directory for enumeration. On input:
+\begin{itemize}
+\item \Param{0,1} points to the length-prefixed filename string.
+\end{itemize}
+Only one directory at a time may be opened. If a directory is already
+open when this call is made, it is automatically closed; however, an
+open directory may make it impossible to delete the directory, so
+closing the directory after use is good practice.
 }
 \ApiFnRow{18}{Read Directory}{
-Read Directory
-\newline TODO: explain this function and any parameters
+Reads an item from the currently open directory. On input:
+\begin{itemize}
+\item \Param{0,1} points to a length-prefixed buffer for returning the filename.
+\end{itemize}
+\begin{itemize}
+\item \Param{0,1} is unchanged, but the buffer is updated to contain the
+length-prefixed filename (without any leading path);
+\item \Param{2,3,4,5} contains the length of the file;
+\item \Param{6} contains the file attributes, as described by the Stat File call.
+\end{itemize}
+This call fails if there are no more items to read.
 }
 \ApiFnRow{19}{Close Directory}{
-Close Directory
-\newline TODO: explain this function and any parameters
+Closes any directory opened by Open Directory.
 }
 \ApiFnRow{20}{Copy File}{
-Copy File
-\newline TODO: explain this function and any parameters
+Copies a file. On input:
+\begin{itemize}
+\item \Param{0,1} points to the length-prefixed old filename;
+\item \Param{2,3} points to the length-prefixed new filename.
+\end{itemize}
+Only single files may be copied, not directories.
 }
 \ApiFnRow{32}{List Filtered}{
-Display the file listing of the present directory,
-filtered per the length-prefixed string
-stored at the memory location specified in \Param{0,1}.
+Prints a filtered file listing of the current directory to the console. On input:
+\begin{itemize}
+\item \Param{0,1} points to the filename search string.
+\end{itemize}
+Files will only be shown if the name contains the search string (via a
+subtring match).
 }
-\end{tabular}
-\end{table}
-
-
+\end{longtable*}
 \pagebreak
-
-
-\begin{table}[h]
-\centering\textbf{Group 4 - Mathematics Functions}
-\begin{tabular}{ | c | l | p{12cm} | }
+\begin{longtable*}{ | c | l | p{12cm} | }
+\caption*{Group 4 - Mathematics Functions} \\
 \hline
 \textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
 \hline
+\endfirsthead
+\caption*{Group 4 - Mathematics Functions (continued)} \\
+\hline
+\textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
+\hline
+\endhead
 \ApiFnRow{0}{Addition}{
 Addition
 \newline Register1 := Register 1 + Register2
@@ -613,19 +723,6 @@ Square Root
 Sine
 \newline Register1 := sine(Register 1) angles in degrees
 }
-\end{tabular}
-\end{table}
-
-
-\pagebreak
-
-
-\begin{table}[h]
-\centering\textbf{Group 4 - Mathematics Functions (continued)}
-\begin{tabular}{ | c | l | p{12cm} | }
-\hline
-\textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
-\hline
 \ApiFnRow{20}{Cosine}{
 Cosine
 \newline Register1 := cosine(Register 1) angles in degrees
@@ -674,19 +771,19 @@ String to Number
 Number to String
 \newline TODO: Convert the constant in Register1 to a length prefixed string which is stored at \Param{4,5}
 }
-\end{tabular}
-\end{table}
-
-
+\end{longtable*}
 \pagebreak
-
-
-\begin{table}[h]
-\centering\textbf{Group 5 - Graphics Functions}
-\begin{tabular}{ | c | l | p{12cm} | }
+\begin{longtable*}{ | c | l | p{12cm} | }
+\caption*{Group 5 - Graphics Functions} \\
 \hline
 \textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
 \hline
+\endfirsthead
+\caption*{Group 5 - Graphics Functions (continued)} \\
+\hline
+\textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
+\hline
+\endhead
 \ApiFnRow{1}{Set Defaults}{
 Configure the global graphics system settings.
 Not all parameters are relevant for all graphics commands;
@@ -728,19 +825,6 @@ Draw the length-prefixed string of text stored
 at the memory location specified in \Param{4,5}
 at the screen character cell specified in \Param{0,1},\Param{2,3} (X,Y).
 }
-\end{tabular}
-\end{table}
-
-
-\pagebreak
-
-
-\begin{table}[h]
-\centering\textbf{Group 5 - Graphics Functions (continued)}
-\begin{tabular}{ | c | l | p{12cm} | }
-\hline
-\textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
-\hline
 \ApiFnRow{7}{Draw Image}{
 Draw the image with image ID in \Param{4}
 at the screen coordinates \Param{0,1},\Param{2,3} (X,Y).
@@ -782,19 +866,6 @@ Deposit into \Param{0..3},
 the number of v-blanks (full screen redraws) which have occurred since power-on.
 This is updated at the start of each v-blank period.
 }
-\end{tabular}
-\end{table}
-
-
-\pagebreak
-
-
-\begin{table}[h]
-\centering\textbf{Group 5 - Graphics Functions (continued)}
-\begin{tabular}{ | c | l | p{12cm} | }
-\hline
-\textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
-\hline
 \ApiFnRow{64}{Set Color}{
 Set Color
 \newline Sets the current drawing colour to \Param{0}
@@ -811,19 +882,19 @@ Set Draw Size
 Set Flip Bits
 \newline Sets the flip bits for drawing images. Bit 0 set causes a horizontal flip, bit 1 set causes a vertical flip.
 }
-\end{tabular}
-\end{table}
-
-
+\end{longtable*}
 \pagebreak
-
-
-\begin{table}[h]
-\centering\textbf{Group 6 - Sprites Functions}
-\begin{tabular}{ | c | l | p{12cm} | }
+\begin{longtable*}{ | c | l | p{12cm} | }
+\caption*{Group 6 - Sprites Functions} \\
 \hline
 \textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
 \hline
+\endfirsthead
+\caption*{Group 6 - Sprites Functions (continued)} \\
+\hline
+\textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
+\hline
+\endhead
 \ApiFnRow{1}{Sprite Reset}{
 Reset the sprite system.
 }
@@ -852,19 +923,19 @@ and the center of the sprite with index specified in \Param{1} .
 Deposit into \Param{1..4}, the screen coordinates of the sprite
 with the index specified in \Param{0}.
 }
-\end{tabular}
-\end{table}
-
-
+\end{longtable*}
 \pagebreak
-
-
-\begin{table}[h]
-\centering\textbf{Group 7 - Controller Functions}
-\begin{tabular}{ | c | l | p{12cm} | }
+\begin{longtable*}{ | c | l | p{12cm} | }
+\caption*{Group 7 - Controller Functions} \\
 \hline
 \textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
 \hline
+\endfirsthead
+\caption*{Group 7 - Controller Functions (continued)} \\
+\hline
+\textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
+\hline
+\endhead
 \ApiFnRow{1}{Read Controller}{
 This reads the status of the default controller into \Param{0}
 \newline Initially, the Controller is the keyboard.
@@ -879,19 +950,19 @@ controllers becomes available. However, it will maintain backward compatibility.
 
 \ParamBits{\$FF04 - Controller Flags}{0}{0}{B}{A}{Down}{Up}{Right}{Left}
 }
-\end{tabular}
-\end{table}
-
-
+\end{longtable*}
 \pagebreak
-
-
-\begin{table}[h]
-\centering\textbf{Group 8 - Sound Functions}
-\begin{tabular}{ | c | l | p{12cm} | }
+\begin{longtable*}{ | c | l | p{12cm} | }
+\caption*{Group 8 - Sound Functions} \\
 \hline
 \textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
 \hline
+\endfirsthead
+\caption*{Group 8 - Sound Functions (continued)} \\
+\hline
+\textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
+\hline
+\endhead
 \ApiFnRow{1}{Reset Sound}{
 Reset the sound system.
 This empties all channel queues and silences all channels immediately.
@@ -919,19 +990,19 @@ Deposit in \Param{0} the number of notes outstanding before silence
 in the queue of the channel specified in \Param{0},
 including the current playing sound, if any.
 }
-\end{tabular}
-\end{table}
-
-
+\end{longtable*}
 \pagebreak
-
-
-\begin{table}[h]
-\centering\textbf{Group 9 - Turtle Graphics Functions}
-\begin{tabular}{ | c | l | p{12cm} | }
+\begin{longtable*}{ | c | l | p{12cm} | }
+\caption*{Group 9 - Turtle Graphics Functions} \\
 \hline
 \textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
 \hline
+\endfirsthead
+\caption*{Group 9 - Turtle Graphics Functions (continued)} \\
+\hline
+\textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
+\hline
+\endhead
 \ApiFnRow{1}{Turtle Initialise}{
 Initialise the turtle graphics system.
 \Param{0} is the sprite number to use for the turtle,
@@ -951,19 +1022,19 @@ Hide the turtle.
 \ApiFnRow{5}{Turtle Home}{
 Move the turtle to the home position (in the center, pointing upward).
 }
-\end{tabular}
-\end{table}
-
-
+\end{longtable*}
 \pagebreak
-
-
-\begin{table}[h]
-\centering\textbf{Group 10 - UExt I/O Functions}
-\begin{tabular}{ | c | l | p{12cm} | }
+\begin{longtable*}{ | c | l | p{12cm} | }
+\caption*{Group 10 - UExt I/O Functions} \\
 \hline
 \textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
 \hline
+\endfirsthead
+\caption*{Group 10 - UExt I/O Functions (continued)} \\
+\hline
+\textbf{Function} & \textbf{Assembly} & \textbf{Description} \\
+\hline
+\endhead
 \ApiFnRow{1}{UExt Initialise}{
 Initialise the UExt I/O system.
 This resets the IO system to its default state, where all UEXT pins are I/O pins,
@@ -997,10 +1068,7 @@ P1P0 = GPIOAnalogue(P0)
 \newline Read the analogue value on UEXT Pin \Param{0} ; this has to be set to analogue type to work. Returns a value
 from 0..4095 stored in \Param{0,1}, which represents an input value of 0 to 3.3 volts.
 }
-\end{tabular}
-\end{table}
-
-
+\end{longtable*}
 
 % makedispatch: END
 

--- a/documents/release/source/api.tex.in
+++ b/documents/release/source/api.tex.in
@@ -7,6 +7,8 @@
 \usepackage{makecell}
 \usepackage{multirow}
 \usepackage{tabularx}
+\usepackage{longtable}
+\usepackage{caption}
 \usepackage{wrapfig}
 
 \renewcommand{\familydefault}{\sfdefault}

--- a/firmware/common/config/system/group3_fileio.inc
+++ b/firmware/common/config/system/group3_fileio.inc
@@ -370,4 +370,4 @@ GROUP 3 ,0,9 File I/O
         \end{itemize}
 
         Files will only be shown if the name contains the search string (via a
-        subtring match).
+        substring match).

--- a/firmware/common/config/system/group3_fileio.inc
+++ b/firmware/common/config/system/group3_fileio.inc
@@ -27,38 +27,86 @@ GROUP 3 ,0,9 File I/O
     FUNCTION 2 Load File
         *DERROR = FIOReadFile(DSPGetStdString(DCOMMAND,4),DSPGetInt16(DCOMMAND,6),DCOMMAND);
     DOCUMENTATION
-        Load a file by name, per the length-prefixed string stored at the memory location
-        specified in \Param{0,1} into to the memory location specified in \Param{2,3}.
-        When the command completes, an error/status code will be in \Param{0}.
-        If the address in \Param{2,3} is \MonoSp{$FFFF}, the file will be loaded into the
+        Load a file by name into memory. On input:
+        
+        \begin{itemize}
+        \item \Param{0,1} points to the length-prefixed filename string;
+        \item \Param{2,3} contains the location to write the data to. If the
+        address is \MonoSp{$FFFF}, the file will instead be loaded into the
         graphics working memory, used for sprites, tiles, images.
+        \end{itemize}
+
+        On output:
+
+        \begin{itemize}
+        \item \Param{0} contains an error/status code.
+        \end{itemize}
 
     FUNCTION 3 Store File
         *DERROR = FIOWriteFile(DSPGetStdString(DCOMMAND,4),DSPGetInt16(DCOMMAND,6),DSPGetInt16(DCOMMAND,8));
     DOCUMENTATION
-        Save the data stored at the memory location specified in \Param{2,3} to storage,
-        as a file with the specified filename, per the length-prefixed string
-        stored at the memory location specified in \Param{0,1}.
-        \Param{4,5} specify the number of bytes to store.
-        When the command completes, an error/status code will be in \Param{0}.
+        Saves data in memory to a file. On input:
+
+        \begin{itemize}
+        \item \Param{0,1} points to the length-prefixed filename string;
+        \item \Param{2,3} contains the location to read data from;
+        \item \Param{4,5} specified the number of bytes to styore.
+        \end{itemize}
+
+        On output:
+
+        \begin{itemize}
+        \item \Param{0} contains an error/status code.
+        \end{itemize}
 
     FUNCTION 4 File Open
         *DERROR = FIOOpenFileHandle(DPARAMS[0],DSPGetStdString(DPARAMS,1),DPARAMS[3]);
     DOCUMENTATION
-        File Open
-        \newline TODO: explain this function and any parameters
+        Opens a file into a specific channel. On input:
+        
+        \begin{itemize}
+        \item \Param{0} contains the file channel to open;
+        \item \Param{1,2} contains the length-prefixed filename;
+        \item \Param{3} contains the open mode. See below.
+        \end{itemize}
+
+        Valid open modes are:
+
+        \begin{itemize}
+        \item 0 opens the file for read-only access;
+        \item 1 opens the file for write-only access;
+        \item 2 opens the file for read-write access;
+        \item 3 creates the file if it doesn't already exist, truncates it if it
+        does, and opens the file for read-write access.
+        \end{itemize}
+
+        Modes 0 to 2 will fail if the file does not already exist. If the
+        channel is already open, the call fails. Opening the same file more than
+        once on different channels has undefined behaviour and is not
+        recommended.
 
     FUNCTION 5 File Close
         *DERROR = FIOCloseFileHandle(DPARAMS[0]);
     DOCUMENTATION
-        File Close
-        \newline TODO: explain this function and any parameters
+        Closes a particular channel. On input:
+
+        \begin{itemize}
+        \item \Param{0} contains the file channel to close.
+        \end{itemize}
 
     FUNCTION 6 File Seek
         *DERROR = FIOSeekFileHandle(DPARAMS[0],DSPGetInt32(DPARAMS,1));
     DOCUMENTATION
-        File Seek
-        \newline TODO: explain this function and any parameters
+        Seeks the file opened on a particular channel to a location. On input:
+
+        \begin{itemize}
+        \item \Param{0} contains the file channel to operate on;
+        \item \Param{1,2,3,4} contains the file location.
+        \end{itemize}
+
+        You can seek beyond the end of a file to extend the file. Whether the
+        file size changes when the seek happens or when you perform the write is
+        undefined.
 
     FUNCTION 7 File Tell
     {
@@ -67,7 +115,17 @@ GROUP 3 ,0,9 File I/O
         DSPSetInt32(DPARAMS,1,pos);
     }
     DOCUMENTATION
-        Deposits the current seek position (byte-offset) into \Param{4}.
+        Returns the current seek location for the file opened on a particular channel. On input:
+
+        \begin{itemize}
+        \item \Param{0} contains the file channel to operate on.
+        \end{itemize}
+
+        On output:
+
+        \begin{itemize}
+        \item \Param{1,2,3,4} contains the file location.
+        \end{itemize}
 
     FUNCTION 8 File Read
     {
@@ -76,8 +134,23 @@ GROUP 3 ,0,9 File I/O
         DSPSetInt16(DPARAMS,3,size);
     }
     DOCUMENTATION
-        File Read
-        \newline TODO: explain this function and any parameters
+        Reads data from an opened file. On input:
+
+        \begin{itemize}
+        \item \Param{0} contains the file channel to operate on;
+        \item \Param{1,2} points to the destination in memory, or \MonoSp{$FFFF}
+        to write to graphics memory;
+        \item \Param{2,3} contains the amount of data to read.
+        \end{itemize}
+
+        On output:
+
+        \begin{itemize}
+        \item \Param{2,3} is updated to contain the amount of data actually read.
+        \end{itemize}
+
+        Data is read from the current seek position, which is advanced after the
+        read.
 
     FUNCTION 9 File Write
     {
@@ -86,8 +159,22 @@ GROUP 3 ,0,9 File I/O
         DSPSetInt16(DPARAMS,3,size);
     }
     DOCUMENTATION
-        File Write
-        \newline TODO: explain this function and any parameters
+        Writes data to an opened file. On input:
+
+        \begin{itemize}
+        \item \Param{0} contains the file channel to operate on;
+        \item \Param{1,2} points to the data in memory;
+        \item \Param{2,3} contains the amount of data to write.
+        \end{itemize}
+
+        On output:
+
+        \begin{itemize}
+        \item \Param{2,3} is updated to contain the amount of data actually written.
+        \end{itemize}
+
+        Data is written to the current seek position, which is advanced after the
+        write.
 
     FUNCTION 10 File Size
     {
@@ -96,48 +183,83 @@ GROUP 3 ,0,9 File I/O
         DSPSetInt32(DPARAMS,1,size);
     }
     DOCUMENTATION
-        File Size
-        \newline TODO: explain this function and any parameters
+        Returns the current size of an opened file. On input:
+
+        \begin{itemize}
+        \item \Param{0} contains the file channel to operate on.
+        \end{itemize}
+
+        On output:
+
+        \begin{itemize}
+        \item \Param{1,2,3,4} contains the size of the file.
+        \end{itemize}
+
+        This call should be used on open files and takes into account any
+        buffered data which has not yet been written to disk. As a result it may
+        return a different size to the stat API call described below.
 
     FUNCTION 11 File Set Size
     {
         *DERROR = FIOSetSizeFileHandle(DPARAMS[0],DSPGetInt32(DPARAMS,1));
     }
     DOCUMENTATION
-        File Set Size
-        \newline TODO: explain this function and any parameters
+        Extends or truncates an opened file to a particular size. On input:
+
+        \begin{itemize}
+        \item \Param{0} contains the file channel to operate on;
+        \item \Param{1,2,3,4} contains the new size of the file.
+        \end{itemize}
 
     FUNCTION 12 File Rename
     {
         *DERROR = FIORenameFile(DSPGetStdString(DPARAMS, 0), DSPGetStdString(DPARAMS, 2));
     }
     DOCUMENTATION
-        File Rename
-        \newline TODO: explain this function and any parameters
+        Renames a file. On input:
+
+        \begin{itemize}
+        \item \Param{0,1} points to the length-prefixed string for the old name;
+        \item \Param{2,3} points to the length-prefixed string for the new name.
+        \end{itemize}
+
+        Files may be renamed across directories.
 
     FUNCTION 13 Delete File
     {
         *DERROR = FIODeleteFile(DSPGetStdString(DPARAMS, 0));
     }
     DOCUMENTATION
-        Delete File
-        \newline TODO: explain this function and any parameters
+        Deletes a file or directory. On input:
+
+        \begin{itemize}
+        \item \Param{0,1} points to the length-prefixed filename string.
+        \end{itemize}
+
+        Deleting a file which is open has undefined behaviour. Directories may
+        only be deleted if they are empty.
 
     FUNCTION 14 Create Directory
     {
         *DERROR = FIOCreateDirectory(DSPGetStdString(DPARAMS, 0));
     }
     DOCUMENTATION
-        Create Directory
-        \newline TODO: explain this function and any parameters
+        Creates a new directory. On input:
+
+        \begin{itemize}
+        \item \Param{0,1} points to the length-prefixed filename string.
+        \end{itemize}
 
     FUNCTION 15 Change Directory
         {
         *DERROR = FIOChangeDirectory(DSPGetStdString(DPARAMS, 0));
         }
     DOCUMENTATION
-        Change Directory
-        \newline TODO: explain this function and any parameters
+        Changes the current working directory. On input:
+
+        \begin{itemize}
+        \item \Param{0,1} points to the length-prefixed path string.
+        \end{itemize}
 
     FUNCTION 16 Stat File
     {
@@ -148,49 +270,104 @@ GROUP 3 ,0,9 File I/O
         DPARAMS[4] = type;
     }
     DOCUMENTATION
-        Stat File
-        \newline TODO: explain this function and any parameters
+        Retrieves information about a file by name. On input:
+
+        \begin{itemize}
+        \item \Param{0,1} points to the length-prefixed filename string.
+        \end{itemize}
+
+        On output:
+
+        \begin{itemize}
+        \item \Param{0,1,2,3} contains the length of the file;
+        \item \Param{4} contains the attribute bitfield of the file.
+        \end{itemize}
+
+        If the file is open for writing, this may not return the correct size
+        due to buffered data not having been flushed to disk.
+
+        File attributes are a bitfield as follows:
+        
+        \newline
+        \ParamBits{File attributes}
+            {0}
+            {0}
+            {0}
+            {Hidden}
+            {Read only}
+            {Archive}
+            {System}
+            {Directory}
 
     FUNCTION 17 Open Directory
     {
         *DERROR = FIOOpenDir(DSPGetStdString(DPARAMS, 0));
     }
     DOCUMENTATION
-        Open Directory
-        \newline TODO: explain this function and any parameters
+        Opens a directory for enumeration. On input:
+
+        \begin{itemize}
+        \item \Param{0,1} points to the length-prefixed filename string.
+        \end{itemize}
+
+        Only one directory at a time may be opened. If a directory is already
+        open when this call is made, it is automatically closed; however, an
+        open directory may make it impossible to delete the directory, so
+        closing the directory after use is good practice.
 
     FUNCTION 18 Read Directory
         {
-        std::string filename;
-        uint32_t size;
-        uint8_t attribs;
-        *DERROR = FIOReadDir(filename, &size, &attribs);
-        DSPSetStdString(DPARAMS, 0, filename);
-        DSPSetInt32(DPARAMS, 2, size);
-        DPARAMS[6] = attribs;
+            std::string filename;
+            uint32_t size;
+            uint8_t attribs;
+            *DERROR = FIOReadDir(filename, &size, &attribs);
+            DSPSetStdString(DPARAMS, 0, filename);
+            DSPSetInt32(DPARAMS, 2, size);
+            DPARAMS[6] = attribs;
         }
     DOCUMENTATION
-        Read Directory
-        \newline TODO: explain this function and any parameters
+        Reads an item from the currently open directory. On input:
+
+        \begin{itemize}
+        \item \Param{0,1} points to a length-prefixed buffer for returning the filename.
+        \end{itemize}
+
+        \begin{itemize}
+        \item \Param{0,1} is unchanged, but the buffer is updated to contain the
+        length-prefixed filename (without any leading path);
+        \item \Param{2,3,4,5} contains the length of the file;
+        \item \Param{6} contains the file attributes, as described by the Stat File call.
+        \end{itemize}
+
+        This call fails if there are no more items to read.
 
     FUNCTION 19 Close Directory
         {
             *DERROR = FIOCloseDir();
         }
     DOCUMENTATION
-        Close Directory
-        \newline TODO: explain this function and any parameters
+        Closes any directory opened by Open Directory.
 
     FUNCTION 20 Copy File
         *DERROR = FIOCopyFile(DSPGetStdString(DPARAMS, 0), DSPGetStdString(DPARAMS, 2));
     DOCUMENTATION
-        Copy File
-        \newline TODO: explain this function and any parameters
+        Copies a file. On input:
+
+        \begin{itemize}
+        \item \Param{0,1} points to the length-prefixed old filename;
+        \item \Param{2,3} points to the length-prefixed new filename.
+        \end{itemize}
+
+        Only single files may be copied, not directories.
 
     FUNCTION 32 List Filtered
         FIODirectory(DSPGetString(DCOMMAND,4));
     DOCUMENTATION
-        Display the file listing of the present directory,
-        filtered per the length-prefixed string
-        stored at the memory location specified in \Param{0,1}.
+        Prints a filtered file listing of the current directory to the console. On input:
 
+        \begin{itemize}
+        \item \Param{0,1} points to the filename search string.
+        \end{itemize}
+
+        Files will only be shown if the name contains the search string (via a
+        subtring match).

--- a/firmware/common/scripts/makedispatch.py
+++ b/firmware/common/scripts/makedispatch.py
@@ -186,16 +186,23 @@ class DispatchAPI(object):
 
 	# generate documentation binaries
 	def renderTableHead(self,fn_table_tex,header):
-		fn_table_tex.append('\\begin{table}[h]')
-		fn_table_tex.append('\\centering\\textbf{%s}' % header)
-		fn_table_tex.append('\\begin{tabular}{ | c | l | p{12cm} | }')
+		#fn_table_tex.append('\\centering\\textbf{%s}' % header)
+		fn_table_tex.append('\\begin{longtable*}{ | c | l | p{12cm} | }')
+
+		fn_table_tex.append('\\caption*{%s} \\\\' % header)
 		fn_table_tex.append('\\hline')
 		fn_table_tex.append("\\textbf{Function} & \\textbf{Assembly} & \\textbf{Description} \\\\")
 		fn_table_tex.append('\\hline')
+		fn_table_tex.append('\\endfirsthead')
+
+		fn_table_tex.append('\\caption*{%s (continued)} \\\\' % header)
+		fn_table_tex.append('\\hline')
+		fn_table_tex.append("\\textbf{Function} & \\textbf{Assembly} & \\textbf{Description} \\\\")
+		fn_table_tex.append('\\hline')
+		fn_table_tex.append('\\endhead')
 
 	def renderTableTail(self,fn_table_tex):
-		fn_table_tex.append('\\end{tabular}')
-		fn_table_tex.extend(['\\end{table}' , '' , '' ])
+		fn_table_tex.append('\\end{longtable*}')
 
 	def renderDocs(self):
 		rev_date     = str(date.fromtimestamp(os.stat(CFG_FILE).st_ctime))
@@ -208,16 +215,9 @@ class DispatchAPI(object):
 			fn_ids = sorted([ fn_id for fn_id in group.functions.keys() ])
 
 			for fn_id in fn_ids:
-				# split table across multiple pages, if specified
-				if group.pageBreaks and fn_id >= group.pageBreaks[0]:
-					group.pageBreaks.pop(0)
-					if fn_id != fn_ids[0]:
-						self.renderTableTail(fn_table_tex)
-						if not header.endswith('(continued)'):
-							header = header + " (continued)"
-					fn_table_tex.extend([ '\pagebreak' , '' , '' ])
-					self.renderTableHead(fn_table_tex , header)
-				elif fn_id == fn_ids[0]:
+				if fn_id == fn_ids[0]:
+					if group_id != 1:
+						fn_table_tex.append('\\pagebreak')
 					self.renderTableHead(fn_table_tex , header)
 
 				function = group.functions[fn_id]

--- a/release/Makefile
+++ b/release/Makefile
@@ -85,4 +85,6 @@ documentation:
 	# generate ODTs (requires 'pandoc')
 	pandoc -f latex -t odt -o $(DOCDIR)api.odt $(DOCDIR)source$(S)api.tex
 	# generate PDFs (requires 'texlive-latex', 'texlive-latexextra', 'texlive-latex-recommended')
+	# Yes, twice! Because tables!
+	pdflatex -output-directory=$(DOCDIR)       $(DOCDIR)source$(S)api.tex
 	pdflatex -output-directory=$(DOCDIR)       $(DOCDIR)source$(S)api.tex


### PR DESCRIPTION
I had to tinker with the Latex table rendering, because some very weird things were happening --- the table wasn't being page wrapped properly and pages were being floated to the end of the document. 

The itemised lists probably also want a custom environment to remove the line spacing to improve readability a little.