### PR TITLE
Timeout on USB key check

### DIFF
--- a/firmware/sources/hardware/storage/usb_storage.cpp
+++ b/firmware/sources/hardware/storage/usb_storage.cpp
@@ -26,9 +26,11 @@ void STOInitialise(void) {
 
 void STOSynchronise(void) {
     CONWriteString("USB Storage\rWaiting for USB Key\r");
-    while (!msc_inquiry_complete) {
+    uint16_t timeOut = 2000;
+    while (!msc_inquiry_complete && timeOut > 0) {
         KBDSync();
         sleep_us(1000);
+        timeOut--;
     }
 }
 


### PR DESCRIPTION
2s timeout on USB key. Seems to take 0.5-1.0s or so to start up. Timeout too early fails configuration (e.g. locale setting)/

Fixes #243 