### PR TITLE
Fixed -ve int()

### DIFF
--- a/basic/test.bsc
+++ b/basic/test.bsc
@@ -1,5 +1,2 @@
-a$ = "breakout.bas"
-poke $100,len(a$)
-for i = 1 to len(a$):poke $100+i,asc(mid$(a$,i,1)):next
-doke $FF04,$100
-sys $FFDF
+print int(-132.4),int(132.4)
+end

--- a/firmware/common/config/mathematics/group4_unary.inc
+++ b/firmware/common/config/mathematics/group4_unary.inc
@@ -25,7 +25,7 @@
 	FUNCTION 17 Floor
 		if (MATHIsFloatBinary()) {
 			f1 = floor(MATHReadFloat(MATH_REG1));
-			MATHWriteInt((uint32_t)f1,MATH_REG1);
+			MATHWriteInt((int32_t)f1,MATH_REG1);
 		}
 	DOCUMENTATION
 		Floor


### PR DESCRIPTION
Wrong casting in int unary dispatch. Fixes #275 