### PR TITLE
make build process more distro-friendly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ endif
 
 all: firmware-deps emulator-deps-nix emulator-deps-win docs-deps
 	$(CMAKEDIR) bin
-	$(CMAKEDIR) release
 	@echo building firmware
 	$(MAKE) -B -C kernel release
 	$(MAKE) -B -C basic release

--- a/Makefile
+++ b/Makefile
@@ -25,36 +25,70 @@ endif
 all:
 	$(CMAKEDIR) bin
 	$(CMAKEDIR) release
+	@echo building firmware
 	$(MAKE) -B -C kernel release
 	$(MAKE) -B -C basic release
 	$(MAKE) -B -C firmware release
+	@echo building emulators
 	$(MAKE) -B -C emulator release
 	$(MAKE) -B -C examples release
+	@echo building release package
 	$(MAKE) -B -C release
 
 
 # ***************************************************************************************
 #
-#							Make windows & linux versions
+# Make firmware only
+#
+# ***************************************************************************************
+
+firmware:
+	@echo building firmware
+	$(CMAKEDIR) bin
+	$(MAKE) -B -C kernel release
+	$(MAKE) -B -C basic release
+	$(MAKE) -B -C firmware release
+
+
+# ***************************************************************************************
+#
+# Make emulator only
 #
 # ***************************************************************************************
 
 windows:
+		@echo building windows emulator
 		$(CMAKEDIR) bin
 		$(MAKE) -B -C kernel
 		$(MAKE) -B -C basic release
 		$(MAKE) -B -C emulator clean
 		$(MAKE) -B -C emulator ewindows
+		$(MAKE) -B -C examples release
 
 linux:
+		@echo building nix emulator
 		$(CMAKEDIR) bin
 		$(MAKE) -B -C kernel
 		$(MAKE) -B -C basic release
 		$(MAKE) -B -C emulator clean
 		$(MAKE) -B -C emulator elinux
+		$(MAKE) -B -C examples release
 
 macos:
+		@echo building macos emulator
 		make -B -C emulator emacos
+		make -B -C examples release
+
+
+# ***************************************************************************************
+#
+# Make documentation only
+#
+# ***************************************************************************************
+
+docs:
+	@echo building documentation
+	$(MAKE) -B -C release documentation
 
 
 # ***************************************************************************************

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 #
 # ***************************************************************************************
 
-all:
+all: firmware-deps emulator-deps-nix emulator-deps-win docs-deps
 	$(CMAKEDIR) bin
 	$(CMAKEDIR) release
 	@echo building firmware
@@ -42,7 +42,7 @@ all:
 #
 # ***************************************************************************************
 
-firmware:
+firmware: firmware-deps
 	@echo building firmware
 	$(CMAKEDIR) bin
 	$(MAKE) -B -C kernel release
@@ -56,7 +56,7 @@ firmware:
 #
 # ***************************************************************************************
 
-windows:
+windows: emulator-deps-nix emulator-deps-win
 		@echo building windows emulator
 		$(CMAKEDIR) bin
 		$(MAKE) -B -C kernel
@@ -65,7 +65,7 @@ windows:
 		$(MAKE) -B -C emulator ewindows
 		$(MAKE) -B -C examples release
 
-linux:
+linux: emulator-deps-nix
 		@echo building nix emulator
 		$(CMAKEDIR) bin
 		$(MAKE) -B -C kernel
@@ -74,7 +74,7 @@ linux:
 		$(MAKE) -B -C emulator elinux
 		$(MAKE) -B -C examples release
 
-macos:
+macos: emulator-deps-nix
 		@echo building macos emulator
 		make -B -C emulator emacos
 		make -B -C examples release
@@ -86,9 +86,41 @@ macos:
 #
 # ***************************************************************************************
 
-docs:
+docs: docs-deps
 	@echo building documentation
 	$(MAKE) -B -C release documentation
+
+
+# ***************************************************************************************
+#
+# Verify that dependencies are installed
+#
+# ***************************************************************************************
+
+firmware-deps:
+	@echo checking for firmware dependencies:
+	@cmake             --version
+	@g++               --version
+	@arm-none-eabi-g++ --version
+	@# NOTE: this is not accounting for 'arm-none-eabi-newlib'
+
+emulator-deps-win:
+	@x86_64-w64-mingw32-g++ --version
+
+emulator-deps-nix:
+	@echo checking for emulator dependencies:
+	@g++         --version
+	@64tass      --version
+	@sdl2-config --version
+	@zip         --version
+	@python3     --version
+	@python -c 'from importlib.metadata import version ; pkg="gitpython" ; print("python-%s: %s" % (pkg , version(pkg)))'
+	@python -c 'from importlib.metadata import version ; pkg="pillow"    ; print("python-%s: %s" % (pkg , version(pkg)))'
+
+docs-deps:
+	@pandoc   --version
+	@pdflatex --version
+	@# NOTE: this is not accounting for the needed latex plugins
 
 
 # ***************************************************************************************

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # ***************************************************************************************
 # ***************************************************************************************
 #
-#		Name : 		Makefile
-#		Author :	Paul Robson (paul@robsons.org.uk)
-#		Date : 		20th November 2023
-#		Reviewed :	No
-#		Purpose :	Main firmware makefile, most of the work is done by CMake.
+# Name     : Makefile
+# Author   : Paul Robson (paul@robsons.org.uk)
+# Date     : 20th November 2023
+# Reviewed : No
+# Purpose  : Main firmware makefile, most of the work is done by CMake.
 #
 # ***************************************************************************************
 # ***************************************************************************************
@@ -16,9 +16,10 @@ else
 include build_env/common.make
 endif
 
+
 # ***************************************************************************************
 #
-#						Remake everything to release state
+# Remake everything to release state
 #
 # ***************************************************************************************
 
@@ -57,27 +58,27 @@ firmware: firmware-deps
 # ***************************************************************************************
 
 windows: emulator-deps-nix emulator-deps-win
-		@echo building windows emulator
-		$(CMAKEDIR) bin
-		$(MAKE) -B -C kernel
-		$(MAKE) -B -C basic release
-		$(MAKE) -B -C emulator clean
-		$(MAKE) -B -C emulator ewindows
-		$(MAKE) -B -C examples release
+	@echo building windows emulator
+	$(CMAKEDIR) bin
+	$(MAKE) -B -C kernel
+	$(MAKE) -B -C basic release
+	$(MAKE) -B -C emulator clean
+	$(MAKE) -B -C emulator ewindows
+	$(MAKE) -B -C examples release
 
 linux: emulator-deps-nix
-		@echo building nix emulator
-		$(CMAKEDIR) bin
-		$(MAKE) -B -C kernel
-		$(MAKE) -B -C basic release
-		$(MAKE) -B -C emulator clean
-		$(MAKE) -B -C emulator elinux
-		$(MAKE) -B -C examples release
+	@echo building nix emulator
+	$(CMAKEDIR) bin
+	$(MAKE) -B -C kernel
+	$(MAKE) -B -C basic release
+	$(MAKE) -B -C emulator clean
+	$(MAKE) -B -C emulator elinux
+	$(MAKE) -B -C examples release
 
 macos: emulator-deps-nix
-		@echo building macos emulator
-		make -B -C emulator emacos
-		make -B -C examples release
+	@echo building macos emulator
+	make -B -C emulator emacos
+	make -B -C examples release
 
 
 # ***************************************************************************************
@@ -125,7 +126,7 @@ docs-deps:
 
 # ***************************************************************************************
 #
-#								Clean everything
+# Clean everything
 #
 # ***************************************************************************************
 
@@ -135,9 +136,10 @@ clean:
 	$(MAKE) -B -C emulator clean
 	$(MAKE) -B -C firmware clean
 
+
 # ***************************************************************************************
 #
-#					  Easy testing of API documentation build
+# Easy testing of API documentation build
 #
 # ***************************************************************************************
 

--- a/basic/images/cvimg.py
+++ b/basic/images/cvimg.py
@@ -15,7 +15,7 @@ from gfxtext import *
 if len(sys.argv) != 3:
 	print("python cvimg.zip <graphics file> <text file>")
 	print("python cvimg.zip <text file> <graphics file> ")
-	sys.exit(1)
+	sys.exit(0)
 
 if sys.argv[1].endswith(".gfx"):
 	GraphicsConvert().toText(sys.argv[1],sys.argv[2])

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -21,7 +21,7 @@ all: basicdemos
 	$(CDEL) samples.zip
 	zip -r samples.zip basic-examples C assembly
 
-release: 
+release:
 	make -B all
 
 # ***************************************************************************************
@@ -50,7 +50,7 @@ clear$(BASDIR):
 %.bas : %.bsc
 	$(PYTHON) $(BINDIR)makebasic.zip $< -o$@
 	$(CCOPY) $@ $< $(BASDIR)
-	
+
 
 # ***************************************************************************************
 #
@@ -59,7 +59,7 @@ clear$(BASDIR):
 # ***************************************************************************************
 
 checkasm:
-	$(ASSEMBLER) -Wno-error=implied-reg code$(S)checkasm.tass -L build/checkasm.lst -o build/asmtest.bin	
+	$(ASSEMBLER) -Wno-error=implied-reg code$(S)checkasm.tass -L build/checkasm.lst -o build/asmtest.bin
 	cmp -b $(BASDIR)/asmtest.inline build/asmtest.bin
 
 # ***************************************************************************************
@@ -69,7 +69,7 @@ checkasm:
 # ***************************************************************************************
 
 basemachine:
-	$(EMULATOR) 
+	$(EMULATOR)
 
 # ***************************************************************************************
 #
@@ -92,4 +92,3 @@ clean:
 	$(CDEL) _include.inc
 	$(CDEL) test.bas
 	$(CDEL) memory.dump
-	

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -3,19 +3,28 @@ cmake_minimum_required(VERSION 3.14)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 
-set(PICO_SDK_FETCH_FROM_GIT on)
+
+if(NOT DEFINED ENV{PICO_SDK_FETCH_FROM_GIT})
+    set(PICO_SDK_FETCH_FROM_GIT on)
+    message("Defaulting PICO_SDK_FETCH_FROM_GIT")
+endif()
 include(pico_sdk_import.cmake)
 
 project(firmware C CXX ASM)
 
 include(FetchContent)
 
-FetchContent_Declare(
-    tinyusb
-    GIT_REPOSITORY https://github.com/hathach/tinyusb.git
-    GIT_TAG        0.16.0
-)
-FetchContent_MakeAvailable(tinyusb)
+# if((NOT DEFINED ENV{PICO_TINYUSB_FETCH_FROM_GIT}) OR ENV{PICO_TINYUSB_FETCH_FROM_GIT})
+if(DEFINED ENV{PICO_TINYUSB_PATH})
+    set(tinyusb_SOURCE_DIR $ENV{PICO_TINYUSB_PATH})
+else()
+    FetchContent_Declare(
+        tinyusb
+        GIT_REPOSITORY https://github.com/hathach/tinyusb.git
+        GIT_TAG        0.16.0
+    )
+    FetchContent_MakeAvailable(tinyusb)
+endif()
 set(PICO_TINYUSB_PATH ${tinyusb_SOURCE_DIR})
 
 pico_sdk_init()
@@ -34,13 +43,17 @@ include_directories(
     common/include
 )
 
-FetchContent_Declare(
-    PicoDVI
-    GIT_REPOSITORY https://github.com/Wren6991/PicoDVI
-    GIT_TAG        a248d72b8cc95a08b43ef4307cd954eb801272b2 # just the latest on 11/12/2023
-)
-FetchContent_MakeAvailable(PicoDVI)
-
+if(DEFINED ENV{PICO_DVI_PATH})
+    set(picodvi_SOURCE_DIR $ENV{PICO_DVI_PATH})
+    set(picodvi_BINARY_DIR "_deps/picodvi-build")
+else()
+    FetchContent_Declare(
+        PicoDVI
+        GIT_REPOSITORY https://github.com/Wren6991/PicoDVI
+        GIT_TAG        a248d72b8cc95a08b43ef4307cd954eb801272b2 # just the latest on 11/12/2023
+    )
+    FetchContent_MakeAvailable(PicoDVI)
+endif()
 add_subdirectory(${picodvi_SOURCE_DIR}/software/libdvi ${picodvi_BINARY_DIR})
 
 add_library(fatfs INTERFACE)

--- a/firmware/common/scripts/makedispatch.py
+++ b/firmware/common/scripts/makedispatch.py
@@ -84,7 +84,7 @@ class Group(object):
 	def render(self):
 		print("\tcase {0}:".format(self.groupID))
 		if self.groupID == 4:
-			print("\t\tMATHCommon(DPARAMS);")		
+			print("\t\tMATHCommon(DPARAMS);")
 		print("\t\tswitch (*DFUNCTION) {")
 		funcs = [x for x in self.functions.keys()]
 		funcs.sort()
@@ -105,17 +105,17 @@ class Group(object):
 
 class DispatchAPI(object):
 	def __init__(self):
-		self.currentFunction = None 
+		self.currentFunction = None
 		self.currentGroup = None
 		self.groups = {}
 		self.parsingState = 'start'
 		self.globalCodeLines = []
 	#
-	def addGroup(self,group):	
-		assert group.getID() not in self.groups 
+	def addGroup(self,group):
+		assert group.getID() not in self.groups
 		self.currentGroup = group
-		self.groups[group.getID()] = group 
-		self.currentFunction = None 
+		self.groups[group.getID()] = group
+		self.currentFunction = None
 	#
 	def addFunction(self,func):
 		assert self.currentGroup is not None
@@ -126,7 +126,7 @@ class DispatchAPI(object):
 		self.globalCodeLines.append(codeLine)
 	#
 	def addDoc(self,docLine):
-		assert self.currentFunction is not None 
+		assert self.currentFunction is not None
 		self.currentFunction.addDoc(docLine)
 	#
 	def addCode(self,codeLine):

--- a/firmware/sources/CMakeLists.txt
+++ b/firmware/sources/CMakeLists.txt
@@ -1,11 +1,16 @@
 add_executable(firmware)
 
-FetchContent_Declare(
-    no-OS-FatFS-SD-SPI-RPi-Pico
-    GIT_REPOSITORY https://github.com/carlk3/no-OS-FatFS-SD-SPI-RPi-Pico.git
-    GIT_TAG        bbccc5d2deea09e128e2576ef35f72b473c5ba5f # just the latest on 30/01/2024
-)
-FetchContent_MakeAvailable(no-OS-FatFS-SD-SPI-RPi-Pico)
+if (DEFINED ENV{PICO_FATFS_PATH})
+    set(no-os-fatfs-sd-spi-rpi-pico_SOURCE_DIR $ENV{PICO_FATFS_PATH})
+    set(no-os-fatfs-sd-spi-rpi-pico_BINARY_DIR "_deps/no-os-fatfs-sd-spi-rpi-pico-build")
+else()
+    FetchContent_Declare(
+        no-OS-FatFS-SD-SPI-RPi-Pico
+        GIT_REPOSITORY https://github.com/carlk3/no-OS-FatFS-SD-SPI-RPi-Pico.git
+        GIT_TAG        bbccc5d2deea09e128e2576ef35f72b473c5ba5f # just the latest on 30/01/2024
+    )
+    FetchContent_MakeAvailable(no-OS-FatFS-SD-SPI-RPi-Pico)
+endif()
 
 pico_generate_pio_header(firmware ${CMAKE_CURRENT_LIST_DIR}/system/sm0_memory_emulation_with_clock.pio)
 

--- a/firmware/sources/CMakeLists.txt
+++ b/firmware/sources/CMakeLists.txt
@@ -18,26 +18,26 @@ add_definitions(-Wno-error=unused-variable)
 
 set(COMMONSRC "../common/sources/interface")
 
-target_sources(firmware PRIVATE main.cpp  
+target_sources(firmware PRIVATE main.cpp
     #
     #       Common ${COMMONSRC} routines
     #
-    ${COMMONSRC}/graphics.cpp  ${COMMONSRC}/console.cpp  ${COMMONSRC}/keyboard.cpp  ${COMMONSRC}/memory.cpp  
-    ${COMMONSRC}/dispatch.cpp  ${COMMONSRC}/maths.cpp  ${COMMONSRC}/config.cpp  ${COMMONSRC}/efla.cpp 
-    ${COMMONSRC}/gfxcommands.cpp  ${COMMONSRC}/ellipse.cpp  ${COMMONSRC}/fileinterface.cpp  
+    ${COMMONSRC}/graphics.cpp  ${COMMONSRC}/console.cpp  ${COMMONSRC}/keyboard.cpp  ${COMMONSRC}/memory.cpp
+    ${COMMONSRC}/dispatch.cpp  ${COMMONSRC}/maths.cpp  ${COMMONSRC}/config.cpp  ${COMMONSRC}/efla.cpp
+    ${COMMONSRC}/gfxcommands.cpp  ${COMMONSRC}/ellipse.cpp  ${COMMONSRC}/fileinterface.cpp
     ${COMMONSRC}/sprites.cpp  ${COMMONSRC}/logo.cpp  ${COMMONSRC}/sprites_xor.cpp  ${COMMONSRC}/tilemap.cpp
     ${COMMONSRC}/sndmanager.cpp  ${COMMONSRC}/sfxmanager.cpp ${COMMONSRC}/tick.cpp ${COMMONSRC}/serialmanager.cpp
     ${COMMONSRC}/turtle.cpp ${COMMONSRC}/locale.cpp ${COMMONSRC}/pininterface.cpp
     #
     #       Hardware sources
     #
-    hardware/dvi_320x240x256.cpp  hardware/usbdriver.cpp  hardware/timer.cpp  hardware/sound.cpp  
+    hardware/dvi_320x240x256.cpp  hardware/usbdriver.cpp  hardware/timer.cpp  hardware/sound.cpp
     hardware/fileimplementation.cpp hardware/tick.cpp hardware/serial.cpp hardware/ports.cpp
     #
     #       CPU type (pretty much permanently PIO now)
     #
-    system/processor_pio.cpp 
-    #system/processor_bitbang.cpp 
+    system/processor_pio.cpp
+    #system/processor_bitbang.cpp
 )
 
 #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")

--- a/release/Makefile
+++ b/release/Makefile
@@ -30,7 +30,7 @@ DOCUMENTS = $(DOCDIR)*.odt $(DOCDIR)*.pdf $(BINDIR)neo6502.inc
 #		Binary files included
 #
 BINARIES = 	 $(BINDIR)*.uf2 $(BINDIR)*.elf \
-			 $(ROOTDIR)emulator$(S)cross-compile$(S)neo.exe $(ROOTDIR)emulator$(S)cross-compile$(S)neo.exe \
+			 $(ROOTDIR)emulator$(S)cross-compile$(S)neo.exe \
 			 $(BINDIR)basic.bin \
 			 $(ROOTDIR)emulator$(S)neo
 #


### PR DESCRIPTION
this change-set does quite a few things, all in the service of distro packaging

* makefiles: allow building firmware, emulators, docs separately
  this reduces the dependency requirements significantly for those who only want to build the emulator, for example
* makefiles: allow strict clean offline build
  - strict: do not exit non-zero for non-fatal reasons
  - clean: ensure that all dependencies are accounted for
  - offline: do not download any external sources at build-time

  this commit implements 'offline' above
  it allows the user to supply the third-party sources in advance, so that networking is not required at build-time
* makefiles: dependency checks
  implements 'clean' above
  exits with an error message for any build dependency which is not satisfied
* cvimg.py: prevent exit failure when sourcing
  implements 'strict' above
  this is for build environments which will fail if any sub-process exits non-zero.
  cvimg.py is apparently sourced (not executed) by another script (imported, whatever pythonically).
  when that happens, the guard which validates the parameters exits non-zero; because no parameters were passed.
