### PR TITLE
Makefile tweak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,8 @@ emulator-deps-nix:
 	@sdl2-config --version
 	@zip         --version
 	@python3     --version
-	@python -c 'from importlib.metadata import version ; pkg="gitpython" ; print("python-%s: %s" % (pkg , version(pkg)))'
-	@python -c 'from importlib.metadata import version ; pkg="pillow"    ; print("python-%s: %s" % (pkg , version(pkg)))'
+#	@python -c 'from importlib.metadata import version ; pkg="gitpython" ; print("python-%s: %s" % (pkg , version(pkg)))'
+#	@python -c 'from importlib.metadata import version ; pkg="pillow"    ; print("python-%s: %s" % (pkg , version(pkg)))'
 
 docs-deps:
 	@pandoc   --version


### PR DESCRIPTION
This is a slight reversion of #285 - I had great difficulty getting the import check to work on my distribution. Seems to be dependency hell. The 'metadata' package isn't in the distro and pip can't cope :(

It doesn't appear to be used anywhere else other than to check install of pillow and gitpython (which are much easier) so this is reverted very slightly to comment those checks while I try to sort it.