### PR TITLE
Enabling . identifiers

### DIFF
--- a/basic/sources/editing/tokenise/helpers/toktypes.asm
+++ b/basic/sources/editing/tokenise/helpers/toktypes.asm
@@ -56,11 +56,13 @@ TOKFail:
 
 ; ************************************************************************************************
 ;
-;								Part of identifier (a-z0-9_)
+;								Part of identifier (a-z0-9_.)
 ;
 ; ************************************************************************************************
 
 TOKIsIdentifierElement:
+		cmp 	#"." 						; check for . or _ which are allowed after the start.
+		beq 	TOKSucceed
 		cmp 	#"_"
 		beq 	TOKSucceed 					; else fall through to alphanumeric
 		

--- a/basic/test.bsc
+++ b/basic/test.bsc
@@ -1,3 +1,3 @@
-poke $8000,$60
-sys $8000
-stop
+hello = 42
+hello.world = 64
+print hello,hello.world


### PR DESCRIPTION
Fixes #282 Actually a bug as identifiers with a period in them actually work using cross development, and in the listing. The only failing was in the tokeniser, which did not recognise '.' as a part of an identifier (it has to not be the first character)