### PR TITLE
Slide fix

### DIFF
--- a/basic/test.bsc
+++ b/basic/test.bsc
@@ -1,3 +1,2 @@
-hello = 42
-hello.world = 64
-print hello,hello.world
+
+sound 0,800,8,-32

--- a/firmware/common/include/interface/sound.h
+++ b/firmware/common/include/interface/sound.h
@@ -20,7 +20,7 @@
 typedef struct _sound_queue_item {
 	uint16_t frequency;
 	uint16_t timeCS;
-	uint16_t slide;
+	int16_t slide;
 	uint8_t  soundType;
 } SOUND_QUEUE_ELEMENT;
 


### PR DESCRIPTION
Fixes #294 
 In casting types between int16_t and int the sign was lost, and it was being treated as a huge slide, which crashed the sound generator. Fixed both conversion and the high pitch crash.