### PR TITLE
Fixed typo in api document sta commands

### DIFF
--- a/documents/release/source/api.tex
+++ b/documents/release/source/api.tex
@@ -83,7 +83,7 @@
 % but is mainly relevant for the API Functions table
 \newcommand{\ApiFnRow}[3] {
   \makecell[tc]{#1 \\ #2}                                      &
-  \makecell[tl]{\MonoSp{LDA \#\$0#1} \\ \MonoSp{STA \#\$FF01}} &
+  \makecell[tl]{\MonoSp{LDA \#\$0#1} \\ \MonoSp{STA \$FF01}} &
   #3                                                           \\ \hline
 }
 

--- a/documents/release/source/api.tex.in
+++ b/documents/release/source/api.tex.in
@@ -78,7 +78,7 @@
 % but is mainly relevant for the API Functions table
 \newcommand{\ApiFnRow}[3] {
   \makecell[tc]{#1 \\ #2}                                      &
-  \makecell[tl]{\MonoSp{LDA \#\$0#1} \\ \MonoSp{STA \#\$FF01}} &
+  \makecell[tl]{\MonoSp{LDA \#\$0#1} \\ \MonoSp{STA \$FF01}} &
   #3                                                           \\ \hline
 }
 


### PR DESCRIPTION
a small typo on STA command. Was STA #$FF01 in every row.