### PR TITLE
fix hit bug

### DIFF
--- a/basic/test.bsc
+++ b/basic/test.bsc
@@ -1,4 +1,7 @@
-repeat
-	f = joypad(x,y)
-	print chr$(20),f,x,y,
-until 0
+cls:gload "graphics.gfx":sprite clear
+
+sprite 0 image $C1 to 10,10
+sprite 1 image $C1 to 20,20
+sprite 1 hide
+print hit(0,1,22)
+

--- a/firmware/common/sources/interface/sprites.cpp
+++ b/firmware/common/sources/interface/sprites.cpp
@@ -277,6 +277,8 @@ uint8_t SPRCollisionCheck(uint8_t *error,uint8_t s1,uint8_t s2,uint8_t distance)
 		*error = 1;
 		return 0;
 	}
+	if ((!sprites[s1].isVisible) || (!sprites[s2].isVisible)) return false;  	// check both visible.
+
 	SPRITE_INTERNAL *p1 = &sprites[s1],*p2 = &sprites[s2]; 						// Structure pointers.
 	int sdist = (p1->xc-p2->xc)*(p1->xc-p2->xc)+(p1->yc-p2->yc)*(p1->yc-p2->yc);// Square of distance
 	return sdist <= distance*distance;
@@ -292,5 +294,6 @@ uint8_t SPRCollisionCheck(uint8_t *error,uint8_t s1,uint8_t s2,uint8_t distance)
 //		16/01/24 	Added SpriteVisibleCount functionality.
 //		23/01/24 	Rationalised SPRITE_ACTION initialisation code.
 //					Added turtle rendering on demand code.
+//		18/03/24 	Sprite collision requires visible sprites.
 //
 // ***************************************************************************************


### PR DESCRIPTION
hit() functionality doesn't account for sprite visibility. Changed SPRCollisionCheck() accordingly.
Fixes #315 