### PR TITLE
Remove cmake fresh from makefile

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -112,13 +112,13 @@ reset:
 dual: prelim always pythonapps
 	$(CDEL)   firmware.elf firmware.uf2
 
-	cmake --fresh -B build -DSDCARD_STORAGE=1
+	cmake -B build -DSTORAGE_TYPE=SDCARD
 	cmake --build build --target clean
 	$(MAKE) -C build
 	$(CCOPY) build$(S)sources$(S)$(BINARY).elf $(BINDIR)$(BINARY)_sd.elf
 	$(CCOPY) build$(S)sources$(S)$(BINARY).uf2 $(BINDIR)$(BINARY)_sd.uf2
 
-	cmake --fresh -B build -DUSBKEY_STORAGE=1
+	cmake -B build -DSTORAGE_TYPE=USB
 	cmake --build build --target clean
 	$(MAKE) -C build
 	$(CCOPY) build$(S)sources$(S)$(BINARY).elf $(BINDIR)$(BINARY)_usb.elf

--- a/firmware/sources/CMakeLists.txt
+++ b/firmware/sources/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_executable(firmware)
 
+set(STORAGE_TYPE "USB" CACHE STRING "Sets your storage type. Can be USB or SDCARD.")
+
 if (DEFINED ENV{PICO_FATFS_PATH})
     set(no-os-fatfs-sd-spi-rpi-pico_SOURCE_DIR $ENV{PICO_FATFS_PATH})
     set(no-os-fatfs-sd-spi-rpi-pico_BINARY_DIR "_deps/no-os-fatfs-sd-spi-rpi-pico-build")
@@ -40,15 +42,17 @@ target_sources(firmware PRIVATE main.cpp
     #system/processor_bitbang.cpp
 )
 
-#set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
-
-if(USBKEY_STORAGE)
-    add_definitions(-DUSBKEY_STORAGE=1)
+if(STORAGE_TYPE STREQUAL "USB")
+    message("Building for USB Storage")
     target_sources(firmware PRIVATE hardware/storage/usb_storage.cpp )
-endif()
-if(SDCARD_STORAGE)
-    add_definitions(-DSDCARD_STORAGE=1)
+    target_link_libraries(firmware fatfs)
+elseif(STORAGE_TYPE STREQUAL "SDCARD")
+    message("Building for SDCARD Storage")
     target_sources(firmware PRIVATE hardware/storage/sdcard_storage.cpp )
+    target_link_libraries(firmware FatFs_SPI)
+    add_subdirectory(${no-os-fatfs-sd-spi-rpi-pico_SOURCE_DIR}/FatFs_SPI ${no-os-fatfs-sd-spi-rpi-pico_BINARY_DIR})
+else()
+    message(FATAL_ERROR "You need to set STORAGE_TYPE!")
 endif()
 
 target_compile_definitions(firmware
@@ -78,14 +82,6 @@ target_link_libraries(firmware
     tinyusb_device
     tinyusb_board
 )
-
-if(USBKEY_STORAGE)
-    target_link_libraries(firmware fatfs)
-endif()
-if(SDCARD_STORAGE)
-    target_link_libraries(firmware FatFs_SPI)
-    add_subdirectory(${no-os-fatfs-sd-spi-rpi-pico_SOURCE_DIR}/FatFs_SPI ${no-os-fatfs-sd-spi-rpi-pico_BINARY_DIR})
-endif()
 
 target_include_directories(firmware PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 pico_add_extra_outputs(firmware)


### PR DESCRIPTION
This removes the fresh option for cmake from the makefile. So we don't need cmake 3.24 or newer anymore. I also change the USB SDCARD switch from two bools to one string. So we don't need to set the inverse to switch. Also USB is now the default if you don't set anything and it will fail if nothing is set.