### PR TITLE
text API fix

### DIFF
--- a/firmware/common/sources/interface/gfxcommands.cpp
+++ b/firmware/common/sources/interface/gfxcommands.cpp
@@ -178,7 +178,7 @@ void GFXScaledText(struct GraphicsMode *gMode,char *s,int x,int y,int useSolidFi
 		uint8_t c = *s++;
 		if ((c >= ' ' && c < 0x80) || (c >= 0xC0)) {
 			int y1 = y;
-			for (int yc = 0;yc < 7;yc++) {				
+			for (int yc = 0;yc < 8;yc++) {				
 				int bits = font_5x7[(c-' ')*8+yc];
 				if (c >= 0xC0) bits = userDefinedFont[(c & 0x3F) * 8 + yc];
 				int x1 = x;


### PR DESCRIPTION
Bottom line of text not displaying using text draw API ; was assuming 5x7 font. Fixes #339 