### PR TITLE
Keyboard modifiers 

### DIFF
--- a/firmware/common/config/system/group1_system.inc
+++ b/firmware/common/config/system/group1_system.inc
@@ -29,8 +29,8 @@ GROUP 1 System
         Deposit the value (32-bits) of the 100Hz system timer into \Param{0..3}.
 
     FUNCTION 2 Key Status
-        i1 = *DPARAMS;
-        *DPARAMS = (i1 < KBD_MAX_KEYCODE) ? KBDGetStateArray()[i1] : 0;
+        i1 = DPARAMS[0];
+        DPARAMS[0] = (i1 < KBD_MAX_KEYCODE) ? KBDGetStateArray()[i1] : 0;
         DPARAMS[1] = KBDGetModifiers();
     DOCUMENTATION
         Deposits the state of the specified keyboard key into \Param{0}.

--- a/firmware/common/config/system/group1_system.inc
+++ b/firmware/common/config/system/group1_system.inc
@@ -31,6 +31,7 @@ GROUP 1 System
     FUNCTION 2 Key Status
         i1 = *DPARAMS;
         *DPARAMS = (i1 < KBD_MAX_KEYCODE) ? KBDGetStateArray()[i1] : 0;
+        DPARAMS[1] = KBDGetModifiers();
     DOCUMENTATION
         Deposit the state of the specified keyboard key into \Param{0}.
         The key which to query is specified in \Param{0}.

--- a/firmware/common/config/system/group1_system.inc
+++ b/firmware/common/config/system/group1_system.inc
@@ -33,7 +33,8 @@ GROUP 1 System
         *DPARAMS = (i1 < KBD_MAX_KEYCODE) ? KBDGetStateArray()[i1] : 0;
         DPARAMS[1] = KBDGetModifiers();
     DOCUMENTATION
-        Deposit the state of the specified keyboard key into \Param{0}.
+        Deposits the state of the specified keyboard key into \Param{0}.
+        State of keyboard modifiers (Shift/Ctrl/Alt/Meta) is returned in \Param{1}.
         The key which to query is specified in \Param{0}.
 
     FUNCTION 3 Basic

--- a/firmware/common/include/interface/keyboard.h
+++ b/firmware/common/include/interface/keyboard.h
@@ -19,6 +19,7 @@ void KBDSync(void);
 void KBDCheckTimer(void);
 void KBDEvent(uint8_t isDown,uint8_t keyCode,uint8_t modifiers);
 uint8_t *KBDGetStateArray(void);
+uint8_t KBDGetModifiers(void);
 bool KBDIsKeyAvailable(void);
 uint8_t KBDGetKey(void);
 void KBDSetLocale(char c1,char c2);

--- a/firmware/common/sources/interface/keyboard.cpp
+++ b/firmware/common/sources/interface/keyboard.cpp
@@ -22,6 +22,7 @@
 //		keycode 8 is byte 1 bit 0 etc.
 //
 static uint8_t keyboardState[KBD_MAX_KEYCODE+1];
+static uint8_t keyboardModifiers;
 //
 //		Queue of ASCII keycode presses.
 //
@@ -58,7 +59,8 @@ void KBDEvent(uint8_t isDown,uint8_t keyCode,uint8_t modifiers) {
 
 	if (keyCode != 0 && keyCode < KBD_MAX_KEYCODE) { 							// Legitimate keycode.
 		if (isDown) {
-			keyboardState[keyCode] = 0xFF; 										// Set down flag.
+			keyboardState[keyCode] = 0xFF; 		
+			keyboardModifiers = modifiers;								// Set down flag.
 			uint8_t ascii = KBDMapToASCII(keyCode,modifiers);  					// What key ?
 			if (ascii != 0) {
 				currentASCII = ascii;  											// Remember code and time.
@@ -68,6 +70,7 @@ void KBDEvent(uint8_t isDown,uint8_t keyCode,uint8_t modifiers) {
 			}
 		} else {
 			keyboardState[keyCode] = 0x00; 										// Clear flag
+			keyboardModifiers = 0x00;								// Set down flag.
 			if (keyCode == currentKeyCode) currentASCII = 0; 					// Autorepeat off, key released.
 		}
 	}
@@ -102,6 +105,10 @@ void KBDCheckTimer(void) {
 uint8_t *KBDGetStateArray(void) {
 	return keyboardState;
 }
+
+uint8_t KBDGetModifiers(void) {
+	return keyboardModifiers;
+};
 
 // ***************************************************************************************
 //

--- a/firmware/common/sources/interface/keyboard.cpp
+++ b/firmware/common/sources/interface/keyboard.cpp
@@ -59,8 +59,8 @@ void KBDEvent(uint8_t isDown,uint8_t keyCode,uint8_t modifiers) {
 
 	if (keyCode != 0 && keyCode < KBD_MAX_KEYCODE) { 							// Legitimate keycode.
 		if (isDown) {
-			keyboardState[keyCode] = 0xFF; 		
-			keyboardModifiers = modifiers;								// Set down flag.
+			keyboardState[keyCode] = 0xFF; 										// Set down flag.
+			keyboardModifiers = modifiers;										// Copy modifiers
 			uint8_t ascii = KBDMapToASCII(keyCode,modifiers);  					// What key ?
 			if (ascii != 0) {
 				currentASCII = ascii;  											// Remember code and time.
@@ -70,7 +70,7 @@ void KBDEvent(uint8_t isDown,uint8_t keyCode,uint8_t modifiers) {
 			}
 		} else {
 			keyboardState[keyCode] = 0x00; 										// Clear flag
-			keyboardModifiers = 0x00;								// Set down flag.
+			keyboardModifiers = 0x00;											// Clear Modifiers
 			if (keyCode == currentKeyCode) currentASCII = 0; 					// Autorepeat off, key released.
 		}
 	}


### PR DESCRIPTION
This is a (backward compatible) modification of API 1.2 
It adds additional information about the state of modifier keys, returned as a second parameter. 

It's just a quick and easy solution, but maybe there's a better way to do it?