### PR TITLE
tokeniser fix

### DIFF
--- a/basic/scripts/makebasic.py
+++ b/basic/scripts/makebasic.py
@@ -39,7 +39,6 @@ class Program(object):
 	#
 	def addFile(self,fileName):
 		for s in open(fileName).readlines():
-			s = s if s.find("//") < 0 else s[:s.find("//")]
 			s = s.strip()
 			if s.startswith("#"):
 				self.command(s[1:])

--- a/basic/scripts/tokeniser.py
+++ b/basic/scripts/tokeniser.py
@@ -83,7 +83,7 @@ class Tokeniser(object):
 	def tokenise(self,s):
 		s = s.strip()
 		self.code = []
-		while s != "":
+		while s != "" and not s.startswith("//"):
 			s = self.tokeniseOne(s).strip()
 		return self.code
 	#

--- a/basic/test.bsc
+++ b/basic/test.bsc
@@ -1,3 +1,5 @@
+// 	Inline comment
+"// quote" // comment
 repeat
 	btn = joypad(dx,dy)
 	cls:print btn,dx,dy


### PR DESCRIPTION
Fixes #351 
Original code strips comments on reading. Changed so the tokeniser itself dumps following code when the token string starts with //