### PR TITLE
CMakelist change

### DIFF
--- a/firmware/sources/CMakeLists.txt
+++ b/firmware/sources/CMakeLists.txt
@@ -20,6 +20,8 @@ add_definitions(-Wno-error=unused-variable)
 
 set(COMMONSRC "../common/sources/interface")
 
+file(GLOB PADSOURCES "hardware/gamepads/*.cpp")
+
 target_sources(firmware PRIVATE main.cpp
     #
     #       Common ${COMMONSRC} routines
@@ -35,8 +37,7 @@ target_sources(firmware PRIVATE main.cpp
     #
     hardware/dvi_320x240x256.cpp  hardware/usbdriver.cpp  hardware/timer.cpp  hardware/sound.cpp
     hardware/fileimplementation.cpp hardware/tick.cpp hardware/serial.cpp hardware/ports.cpp
-    hardware/GamepadController.cpp hardware/gamepads/Gamepad054C0CDA.cpp hardware/gamepads/Gamepad081FE401.cpp
-    hardware/gamepads/Gamepad0079181C.cpp hardware/gamepads/Gamepad007918D2.cpp hardware/gamepads/Gamepad07382217C.cpp 
+    hardware/GamepadController.cpp ${PADSOURCES}
 
     #
     #       CPU type (pretty much permanently PIO now)


### PR DESCRIPTION
Rather than have multiple gamepad .cpp in the source list, uses wildcards.