### PR TITLE
Base Joypad API additive

### DIFF
--- a/basic/test.bsc
+++ b/basic/test.bsc
@@ -1,7 +1,4 @@
-print mos("cd /test1")
-print mos("cd /test2")
-print mos("cd /test9")
-print mos("cd /")
-print mos("xxx")
-print mos("file squash.bas")
-print mos("file squash.basx")
+repeat
+	fire = joypad(dx,dy)
+	cls:print fire,dx,dy
+until 0

--- a/documents/release/source/api.tex
+++ b/documents/release/source/api.tex
@@ -954,11 +954,12 @@ with the index specified in \Param{0}.
 \hline
 \endhead
 \ApiFnRow{1}{Read Default Controller}{
-This reads the status of the default controller into \Param{0}.
+This reads the status of the base controller into \Param{0}, and is a compatibility
+API call.
 \newline
 
-The default controller is the keyboard if no gamepad is inserted. Keys used
-are WASD+OPKL or Arrow Keys+ZXCV
+The base controller is the keyboard keys (these are WASD+OPKL or Arrow Keys+ZXCV) or the
+gamepad controller buttons. Either works.
 \newline
 
 \ParamBits{\$FF04 - Controller Flags}{Y}{X}{B}{A}{Down}{Up}{Right}{Left}

--- a/firmware/common/config/miscellany/group7_controller.inc
+++ b/firmware/common/config/miscellany/group7_controller.inc
@@ -20,18 +20,18 @@
 GROUP 7 Controller
 
     FUNCTION 1 Read Default Controller
-        if (GMPGetControllerCount() == 0) {
-            *DPARAMS = KBDKeyboardController();
-        } else {
-            *DPARAMS = GMPReadDigitalController(0) & 0xFF;
+        *DPARAMS = KBDKeyboardController();
+        if (GMPGetControllerCount() != 0) {
+            *DPARAMS |= GMPReadDigitalController(0) & 0xFF;
         }
 
     DOCUMENTATION
-        This reads the status of the default controller into \Param{0}.
+        This reads the status of the base controller into \Param{0}, and is a compatibility
+        API call.
         \newline
 
-        The default controller is the keyboard if no gamepad is inserted. Keys used
-        are WASD+OPKL or Arrow Keys+ZXCV
+        The base controller is the keyboard keys (these are WASD+OPKL or Arrow Keys+ZXCV) or the 
+        gamepad controller buttons. Either works.
 
         \newline
         \ParamBits{$FF04 - Controller Flags}{Y}{X}{B}{A}{Down}{Up}{Right}{Left}


### PR DESCRIPTION
Makes the original joypad controller API additive, e.g. uses either keypad or gamepad