### PR TITLE
Changed emulator frame rate 60Hz

### DIFF
--- a/emulator/src/core/sys_processor.cpp
+++ b/emulator/src/core/sys_processor.cpp
@@ -24,7 +24,7 @@
 // *******************************************************************************************************************************
 
 #define CYCLE_RATE 		(62*1024*1024/10)											// Cycles per second (6.25Mhz)
-#define FRAME_RATE		(50)														// Frames per second (50 arbitrary)
+#define FRAME_RATE		(60)														// Frames per second (60 same as DVI)
 #define CYCLES_PER_FRAME (CYCLE_RATE / FRAME_RATE)									// Cycles per frame
 
 // *******************************************************************************************************************************

--- a/firmware/common/sources/interface/sweet16.cpp
+++ b/firmware/common/sources/interface/sweet16.cpp
@@ -109,8 +109,8 @@ static void _SW16Status() {
 
 bool SW16Execute(uint16_t reg) {
 	bool bQuitSweet = false;  													// Set by RTN.
-	int32_t yieldCounter = 6000000/50;  										// 6 MIPS , 50 frames per second.	
-	uint16_t temp;
+	int32_t yieldCounter = 6000000/60;  										// 6 MIPS , 60 frames per second 
+	uint16_t temp; 																// (set by the emulator)
 
 	for (int i = 0;i < 16;i++) {  												// Copy cpu memory to working registers
 		sweet_reg[i] = cpuMemory[reg+i*2]+(cpuMemory[reg+i*2+1] << 8);


### PR DESCRIPTION
So it's the same as on hardware. As well as changing the constant in the emulator, this also involves changing the callback rate in the Sweet16 VM.