### PR TITLE
Emulator: Hide mouse cursor on SDL Window

### DIFF
--- a/emulator/src/framework/gfx.cpp
+++ b/emulator/src/framework/gfx.cpp
@@ -68,6 +68,8 @@ void GFXOpenWindow(const char *title,int width,int height,int colour) {
 	Beeper::open();
 	Beeper::setVolume(0.0);
 	Beeper::play();
+
+	SDL_ShowCursor(SDL_DISABLE);                                                    // Hide mouse cursor
 }
 
 // *******************************************************************************************************************************


### PR DESCRIPTION
Morpheus cursor looks better without having the system cursor visible at the same time.