### PR TITLE
Add a "trace" mode to dump out execution to stdout.

### DIFF
--- a/emulator/include/sys_debug_system.h
+++ b/emulator/include/sys_debug_system.h
@@ -48,4 +48,8 @@ void DGBXGetActiveDisplayInfo(SDL_Rect *r,int *pxs,int *pys,int *pxc,int *pyc);
 BYTE8 DRVGFXHandler(BYTE8 key,BYTE8 isRunMode);
 BYTE8 *DBGXGetVideoRAM(void);
 
+int DBGXDasm(int addr, char* buffer);												// Disassemble the instruction at addr, writing into buffer.
+int DBGXInstructionSize(int addr);													// Calc size (1,2 or 3) of instruction found at at addr.
+void DBGXDumpMem(int addr, int nbytes, char* buffer);								// Dump hex bytes out into a string.
+
 #endif

--- a/emulator/src/core/sys_processor.cpp
+++ b/emulator/src/core/sys_processor.cpp
@@ -40,6 +40,7 @@ static char **argumentList;
 static LONG32 cycles;																// Cycle Count.
 static int inFastMode = 0; 															// Fast mode flag (speeds up unit testing)
 static bool useDebuggerKeys = false;  												// Use the debugger keys.
+static bool traceMode = false;														// Dump each CPU instruction to stdout.
 
 // *******************************************************************************************************************************
 //											 Memory and I/O read and write macros.
@@ -141,6 +142,9 @@ void CPUReset(void) {
 			if (strncmp(command,"path:",5) == 0) {  								// Set storage path
 				HWSetDefaultPath(command+5);
 			}
+			if (strcmp(command,"trace") == 0) { 									// Dump every CPU instruction to stdout.
+				traceMode = true;
+			}
 		}
 	}
 	HWReset();																		// Reset Hardware
@@ -175,6 +179,15 @@ BYTE8 CPUExecuteInstruction(void) {
 		CPUExit();
 		return FRAME_RATE;
 	}
+
+    if (traceMode) {
+		char mem[10]; // "XX XX XX \0"
+		char dasm[32];
+		DBGXDumpMem(pc, DBGXInstructionSize(pc), mem);
+		DBGXDasm(pc, dasm);
+		printf("%04x  %-10s %s\n", pc, mem, dasm);
+	}
+
 	BYTE8 opcode = Fetch();															// Fetch opcode.
 	switch(opcode) {																// Execute it.
 		#include "6502/__6502opcodes.h"


### PR DESCRIPTION
Adds a commandline argument: `trace`.
If set, each cpu instruction is disassembled out to stdout just before execution.

Not sure how useful this is to anyone else, but I added it to help track down the bug in https://github.com/llvm-mos/llvm-mos-sdk/issues/330 .

Would be nice to add output for system calls too - I just locally hacked a printf into `DSPHandler()`, but it'd be nice to have the trace mode flag do that.