### PR TITLE
Fix SD Card / SPI not working 

### DIFF
--- a/firmware/sources/hardware/ports.cpp
+++ b/firmware/sources/hardware/ports.cpp
@@ -14,6 +14,42 @@
 
 // ***************************************************************************************
 //
+//                                  GPIO Pins
+//
+// ***************************************************************************************
+
+#define I2C_SCL_PIN    (23)
+#define I2C_SDA_PIN    (22)
+#define I2C_DEVICE      (i2c1)
+
+#define SPI_MISO_PIN    (24)
+#define SPI_MOSI_PIN    (27)
+#define SPI_SCK_PIN     (26)
+#define SPI_CS_PIN      (25)
+
+#define SPI_DEVICE      (spi1)
+
+// ***************************************************************************************
+//
+//                      Check if SPI in use, or SPI pin in use
+//
+// ***************************************************************************************
+
+#if STORAGE_TYPE==SDCARD
+//
+//      SD Card ; don't use the SPI pins or SPI function
+//
+#define INUSE(p)        ((p) == SPI_MISO_PIN || (p) == SPI_MOSI_PIN || (p) == SPI_SCK_PIN || (p) == SPI_CS_PIN)
+#define SPI_BLOCKED
+#else
+//
+//      USB Storage
+//
+#define INUSE(p)        (false)
+#endif
+
+// ***************************************************************************************
+//
 //								Set GPIO Direction
 //
 // ***************************************************************************************
@@ -21,6 +57,9 @@
 static bool isADCInitialised = false;
 
 int UEXTSetGPIODirection(int gpio,int pinType) {
+
+    if (INUSE(gpio)) return 1; 
+
 	gpio_init(gpio);
     if (pinType == UEXT_ANALOGUE) {
         if (!isADCInitialised) adc_init();
@@ -39,6 +78,7 @@ int UEXTSetGPIODirection(int gpio,int pinType) {
 // ***************************************************************************************
 
 int UEXTSetGPIO(int gpio,bool isOn) {
+    if (INUSE(gpio)) return 1; 
     gpio_put(gpio,isOn ? 1 : 0);  		
     return 0;
 }
@@ -50,6 +90,10 @@ int UEXTSetGPIO(int gpio,bool isOn) {
 // ***************************************************************************************
 
 int UEXTGetGPIO(int gpio,bool *pIsHigh) {
+    if (INUSE(gpio)) {
+        *pIsHigh = 0;    
+        return 1; 
+    }
     *pIsHigh = gpio_get(gpio);  												
 	return 0;	
 }
@@ -61,6 +105,10 @@ int UEXTGetGPIO(int gpio,bool *pIsHigh) {
 // ***************************************************************************************
 
 int UEXTGetGPIOAnalogue(int gpio,uint16_t *pLevel) {
+    if (INUSE(gpio)) {
+        *pLevel = 0;    
+        return 1; 
+    }
     adc_select_input(gpio-26);
     *pLevel = adc_read();
     return 0;   
@@ -72,10 +120,6 @@ int UEXTGetGPIOAnalogue(int gpio,uint16_t *pLevel) {
 //
 // ***************************************************************************************
 
-#define I2C_SCL_PIN    (23)
-#define I2C_SDA_PIN    (22)
-
-#define I2C_DEVICE      (i2c1)
 
 int UEXTI2CInitialise(void) {
     i2c_init(I2C_DEVICE, 400 * 1000);
@@ -115,6 +159,7 @@ int UEXTI2CReadBlock(uint8_t device, uint8_t *data,size_t size) {
 //
 // ***************************************************************************************
 
+#ifndef SPI_BLOCKED
 static int reg_read(spi_inst_t *spi,const uint cs,const uint8_t reg,uint8_t *buf,const uint8_t nbytes) {
     int num_bytes_read = 0;
     uint8_t mb = 0;
@@ -132,6 +177,7 @@ static int reg_read(spi_inst_t *spi,const uint cs,const uint8_t reg,uint8_t *buf
     gpio_put(cs, 1);
     return num_bytes_read;
 }
+#endif
 
 // ***************************************************************************************
 //
@@ -139,14 +185,11 @@ static int reg_read(spi_inst_t *spi,const uint cs,const uint8_t reg,uint8_t *buf
 //
 // ***************************************************************************************
 
-#define SPI_MISO_PIN    (24)
-#define SPI_MOSI_PIN    (27)
-#define SPI_SCK_PIN     (26)
-#define SPI_CS_PIN      (25)
-
-#define SPI_DEVICE      (spi1)
 
 int UEXTSPIInitialise(void) {
+    #ifdef SPI_BLOCKED
+    return 1;
+    #else
     gpio_init(SPI_CS_PIN);                                                      // Set SPI pin high
     gpio_set_dir(SPI_CS_PIN, GPIO_OUT);
     gpio_put(SPI_CS_PIN, 1);
@@ -167,6 +210,7 @@ int UEXTSPIInitialise(void) {
     uint8_t data;
     reg_read(SPI_DEVICE, SPI_CS_PIN, 0, &data, 1);                              // Workaround: perform throw-away read to make SCK idle high
     return 0;
+    #endif
 }
 
 // ***************************************************************************************
@@ -176,10 +220,14 @@ int UEXTSPIInitialise(void) {
 // ***************************************************************************************
 
 int UEXTSPIWriteBlock(uint8_t *data,size_t size) {
+    #ifdef SPI_BLOCKED
+    return 1;
+    #else
     gpio_put(SPI_CS_PIN, 0);
     size_t nWritten = spi_write_blocking(SPI_DEVICE, data,size);
     gpio_put(SPI_CS_PIN, 1);   
     return (nWritten == size) ? 0 : 1;    
+    #endif
 }
 
 // ***************************************************************************************
@@ -189,15 +237,20 @@ int UEXTSPIWriteBlock(uint8_t *data,size_t size) {
 // ***************************************************************************************
 
 int UEXTSPIReadBlock(uint8_t *data,size_t size) {
+    #ifdef SPI_BLOCKED
+    return 1;
+    #else
     gpio_put(SPI_CS_PIN, 0);
     size_t nRead = spi_read_blocking(SPI_DEVICE, 0, data,size);
     gpio_put(SPI_CS_PIN, 1);   
     return (nRead == size) ? 0 : 1;    
+    #endif
 }
 
 // ***************************************************************************************
 //
 //		Date 		Revision
 //		==== 		========
+//      02/05/24    Added code to stop interfering with SPI pins.
 //
 // ***************************************************************************************


### PR DESCRIPTION
This is a better version of the original SD Card fix. It stops the API accessing the SPI pins whatever you do.

This does technically mean the SD Card and USB implementations differ, but only in that you can't access pins that are blocked by the SD Card anyway.

