### PR TITLE
Add nibble and transparency support to BltComplexCopy.

### DIFF
--- a/documents/release/source/api.gen.md
+++ b/documents/release/source/api.gen.md
@@ -12,7 +12,8 @@ fontsize: 12pt
 
 ## Function 0 : DSP Reset
 
-Resets the messaging system and component systems. Normally, should not be used.
+Resets the messaging system and component systems.
+Normally, should not be used.
 
 ## Function 1 : Timer
 
@@ -20,7 +21,9 @@ Deposit the value (32-bits) of the 100Hz system timer into Parameters:0..3.
 
 ## Function 2 : Key Status
 
-Deposits the state of the specified keyboard key into Parameter:0. State of keyboard modifiers (Shift/Ctrl/Alt/Meta) is returned in Parameter:1. The key which to query is specified in Parameter:0.
+Deposits the state of the specified keyboard key into Parameter:0.
+State of keyboard modifiers (Shift/Ctrl/Alt/Meta) is returned in Parameter:1.
+The key which to query is specified in Parameter:0.
 
 ## Function 3 : Basic
 
@@ -36,11 +39,14 @@ Check the serial port to see if there is a data transmission.
 
 ## Function 6 : Locale
 
-Set the locale code specified in Parameters:0,1 as upper-case ASCII letters. Parameter:0 takes the first letter and Parameter:1 takes the second letter. For example: French (FR) would require Parametr 0 being $46 and Parameter 1 being $52
+Set the locale code specified in Parameters:0,1 as upper-case ASCII letters.
+Parameter:0 takes the first letter and Parameter:1 takes the second letter.
+For example: French (FR) would require Parametr 0 being $46 and Parameter 1 being $52
 
 ## Function 7 : System Reset
 
-System Reset. This is a full hardware reset. It resets the RP2040 using the Watchdog timer, and this also resets the 65C02.
+System Reset. This is a full hardware reset. It resets the RP2040 using the Watchdog timer, and
+this also resets the 65C02.
 
 ## Function 8 : MOS
 
@@ -48,7 +54,9 @@ Do a MOS command (a '* command') these are specified in the Wiki as they will be
 
 ## Function 9 : Sweet 16 Virtual Machine
 
-Execute Sweet 16 VM Code with the register set provided. The error return value is actually a re-entrant call for Windows emulation ; if it returns non-zero it means the VM has been executed, if it returns zero then the emulation can update as at the end of a normal frame.
+Execute Sweet 16 VM Code with the register set provided. The error return value is actually a re-entrant
+call for Windows emulation ; if it returns non-zero it means the VM has been executed, if it returns zero
+then the emulation can update as at the end of a normal frame.
 
 \newpage
 
@@ -60,27 +68,38 @@ Console out (duplicate of Function 6 for backward compatibility).
 
 ## Function 1 : Read Character
 
-Read and remove a key press from the keyboard queue into Parameter:0. This is the ASCII value of the keystroke. If there are no key presses in the queue, Parameter:0 will be zero. Note that this Function is best for text input, but not for games. Function 7,1 is more optimal for games, as this only detects key presses, you cannot check whether the key is currently down or not.
+Read and remove a key press from the keyboard queue into Parameter:0.
+This is the ASCII value of the keystroke.
+If there are no key presses in the queue, Parameter:0 will be zero.
+Note that this Function is best for text input, but not for games.
+Function 7,1 is more optimal for games, as this only detects key presses,
+you cannot check whether the key is currently down or not.
 
 ## Function 2 : Console Status
 
-Check to see if the keyboard queue is empty. If it is, Parameter:0 will be $FF, otherwise it will be $00
+Check to see if the keyboard queue is empty.
+If it is, Parameter:0 will be $FF, otherwise it will be $00
 
 ## Function 3 : Read Line
 
-Input the current line below the cursor into Parameters:0,1 as a length-prefixed string; and move the cursor to the line below. Handles multiple-line input.
+Input the current line below the cursor into Parameters:0,1 as a length-prefixed string;
+and move the cursor to the line below. Handles multiple-line input.
 
 ## Function 4 : Define Hotkey
 
-Define the function key F1..F10 specified in Parameter:0 as 1..10 to emit the length-prefixed string stored at the memory location specified in Parameters:2,3. F11 and F12 cannot currently be defined.
+Define the function key F1..F10 specified in Parameter:0 as 1..10 to emit the
+length-prefixed string stored at the memory location specified in Parameters:2,3.
+F11 and F12 cannot currently be defined.
 
 ## Function 5 : Define Character
 
-Define a font character specified in Parameter:0 within the range of 192..255. Fill bits 0..5 (columns) of Parameters:1..7 (rows) with the character bitmap.
+Define a font character specified in Parameter:0 within the range of 192..255.
+Fill bits 0..5 (columns) of Parameters:1..7 (rows) with the character bitmap.
 
 ## Function 6 : Write Character
 
-Write the character specified in Parameter:0 to the console at the cursor position. Refer to Section "Console Codes" for details.
+Write the character specified in Parameter:0 to the console at the cursor position.
+Refer to Section "Console Codes" for details.
 
 ## Function 7 : Set Cursor Pos
 
@@ -108,11 +127,13 @@ Clears the screen.
 
 ## Function 13 : Cursor Position
 
-Returns the current screen character cell of the cursor in Parameter:0 (X), Parameter:1 (Y).
+Returns the current screen character cell of the cursor
+in Parameter:0 (X), Parameter:1 (Y).
 
 ## Function 14 : Clear Region
 
-Erase all characters within the rectangular region specified in Parameters:0,1 (begin X,Y) and Parameters:2,3 (end X,Y).
+Erase all characters within the rectangular region specified
+in Parameters:0,1 (begin X,Y) and Parameters:2,3 (end X,Y).
 
 ## Function 15 : Set Text Color
 
@@ -120,7 +141,8 @@ Sets the foreground colour to Parameter:0 and the background colour to Parameter
 
 ## Function 16 : Cursor Inverse
 
-Toggles the cursor colour between normal and inverse (ie: swaps FG and BG colors). This should not be used.
+Toggles the cursor colour between normal and inverse
+(ie: swaps FG and BG colors). This should not be used.
 
 ## Function 17 : Tab() implementation
 
@@ -136,71 +158,151 @@ Display the file listing of the present directory.
 
 ## Function 2 : Load File
 
-Load a file by name into memory. On input: Parameters:0,1 points to the length-prefixed filename string; Parameters:2,3 contains the location to write the data to. If the address is $FFFF, the file will instead be loaded into the graphics working memory, used for sprites, tiles, images. On output: Parameter:0 contains an error/status code.
+Load a file by name into memory. On input:
+Parameters:0,1 points to the length-prefixed filename string;
+Parameters:2,3 contains the location to write the data to. If the
+address is $FFFF, the file will instead be loaded into the
+graphics working memory, used for sprites, tiles, images.
+On output:
+Error location contains an error/status code.
 
 ## Function 3 : Store File
 
-Saves data in memory to a file. On input: Parameters:0,1 points to the length-prefixed filename string; Parameters:2,3 contains the location to read data from; Parameters:4,5 specified the number of bytes to store. On output: Parameter:0 contains an error/status code.
+Saves data in memory to a file. On input:
+Parameters:0,1 points to the length-prefixed filename string;
+Parameters:2,3 contains the location to read data from;
+Parameters:4,5 specified the number of bytes to store.
+On output:
+Error location contains an error/status code.
 
 ## Function 4 : File Open
 
-Opens a file into a specific channel. On input: Parameter:0 contains the file channel to open; Parameters:1,2 points to the length-prefixed filename string; Parameter:3 contains the open mode. See below. Valid open modes are: 0 opens the file for read-only access; 1 opens the file for write-only access; 2 opens the file for read-write access; 3 creates the file if it doesn't already exist, truncates it if it does, and opens the file for read-write access. Modes 0 to 2 will fail if the file does not already exist. If the channel is already open, the call fails. Opening the same file more than once on different channels has undefined behaviour, and is not recommended.
+Opens a file into a specific channel. On input:
+Parameter:0 contains the file channel to open;
+Parameters:1,2 points to the length-prefixed filename string;
+Parameter:3 contains the open mode. See below.
+Valid open modes are:
+0 opens the file for read-only access;
+1 opens the file for write-only access;
+2 opens the file for read-write access;
+3 creates the file if it doesn't already exist, truncates it if it
+does, and opens the file for read-write access.
+Modes 0 to 2 will fail if the file does not already exist. If the
+channel is already open, the call fails. Opening the same file more than
+once on different channels has undefined behaviour, and is not
+recommended.
 
 ## Function 5 : File Close
 
-Closes a particular channel. On input: Parameter:0 contains the file channel to close.
+Closes a particular channel. On input:
+Parameter:0 contains the file channel to close.
 
 ## Function 6 : File Seek
 
-Seeks the file opened on a particular channel to a location. On input: Parameter:0 contains the file channel to operate on; Parameters:1..4 contains the file location. You can seek beyond the end of a file to extend the file. However, whether the file size changes when the seek happens, or when you perform the write is undefined behavior.
+Seeks the file opened on a particular channel to a location. On input:
+Parameter:0 contains the file channel to operate on;
+Parameters:1..4 contains the file location.
+You can seek beyond the end of a file to extend the file.
+However, whether the file size changes when the seek happens,
+or when you perform the write is undefined behavior.
 
 ## Function 7 : File Tell
 
-Returns the current seek location for the file opened on a particular channel. On input: Parameter:0 contains the file channel to operate on. On output: Parameters:1..4 contains the seek location within the file.
+Returns the current seek location for the file opened on a particular channel. On input:
+Parameter:0 contains the file channel to operate on.
+On output:
+Parameters:1..4 contains the seek location within the file.
 
 ## Function 8 : File Read
 
-Reads data from an opened file. On input: Parameter:0 contains the file channel to operate on. Parameters:1,2 points to the destination in memory, or $FFFF to read into graphics memory. Parameters:2,3 contains the amount of data to read. On output: Parameters:3,4 is updated to contain the amount of data actually read. Data is read from the current seek position, which is advanced after the read.
+Reads data from an opened file. On input:
+Parameter:0 contains the file channel to operate on.
+Parameters:1,2 points to the destination in memory,
+or $FFFF to read into graphics memory.
+Parameters:2,3 contains the amount of data to read.
+On output:
+Parameters:3,4 is updated to contain the amount of data actually read.
+Data is read from the current seek position, which is advanced after the read.
 
 ## Function 9 : File Write
 
-Writes data to an opened file. On input: Parameter:0 contains the file channel to operate on; Parameters:1,2 points to the data in memory; Parameters:3,4 contains the amount of data to write. On output: Parameters:3,4 is updated to contain the amount of data actually written. Data is written to the current seek position, which is advanced after the write.
+Writes data to an opened file. On input:
+Parameter:0 contains the file channel to operate on;
+Parameters:1,2 points to the data in memory;
+Parameters:3,4 contains the amount of data to write.
+On output:
+Parameters:3,4 is updated to contain the amount of data actually written.
+Data is written to the current seek position, which is advanced after the write.
 
 ## Function 10 : File Size
 
-Returns the current size of an opened file. On input: Parameter:0 contains the file channel to operate on. On output: Parameters:1..4 contains the size of the file. This call should be used on open files, and takes into account any buffered data which has not yet been written to disk. Consequently, this may return a different size than Function 3,16 "File Stat".
+Returns the current size of an opened file. On input:
+Parameter:0 contains the file channel to operate on.
+On output:
+Parameters:1..4 contains the size of the file.
+This call should be used on open files,
+and takes into account any buffered data which has not yet been written to disk.
+Consequently, this may return a different size than Function 3,16 "File Stat".
 
 ## Function 11 : File Set Size
 
-Extends or truncates an opened file to a particular size. On input: Parameter:0 contains the file channel to operate on; Parameters:1..4 contains the new size of the file.
+Extends or truncates an opened file to a particular size. On input:
+Parameter:0 contains the file channel to operate on;
+Parameters:1..4 contains the new size of the file.
 
 ## Function 12 : File Rename
 
-Renames a file. On input: Parameters:0,1 points to the length-prefixed string for the old name; Parameters:2,3 points to the length-prefixed string for the new name. Files may be renamed across directories.
+Renames a file. On input:
+Parameters:0,1 points to the length-prefixed string for the old name;
+Parameters:2,3 points to the length-prefixed string for the new name.
+Files may be renamed across directories.
 
 ## Function 13 : File Delete
 
-Deletes a file or directory. On input: Parameters:0,1 points to the length-prefixed filename string. Deleting a file which is open has undefined behaviour. Directories may only be deleted if they are empty.
+Deletes a file or directory. On input:
+Parameters:0,1 points to the length-prefixed filename string.
+Deleting a file which is open has undefined behaviour. Directories may
+only be deleted if they are empty.
 
 ## Function 14 : Create Directory
 
-Creates a new directory. On input: Parameters:0,1 points to the length-prefixed filename string.
+Creates a new directory. On input:
+Parameters:0,1 points to the length-prefixed filename string.
 
 ## Function 15 : Change Directory
 
-Changes the current working directory. On input: Parameters:0,1 points to the length-prefixed path string.
+Changes the current working directory. On input:
+Parameters:0,1 points to the length-prefixed path string.
 
 ## Function 16 : File Stat
 
-Retrieves information about a file by name. On input: Parameters:0,1 points to the length-prefixed filename string. Parameters:0..3 contains the length of the file; Parameter:4 contains the attributes bit-field of the file. If the file is open for writing, this may not return the correct size due to buffered data not having been flushed to disk. File attributes are a bitfield as follows: 0,0,0,Hidden, Read Only, Archive, System, Directory.
+Retrieves information about a file by name. On input:
+Parameters:0,1 points to the length-prefixed filename string.
+Parameters:0..3 contains the length of the file;
+Parameter:4 contains the attributes bit-field of the file.
+If the file is open for writing, this may not return the correct size
+due to buffered data not having been flushed to disk.
+File attributes are a bitfield as follows: 0,0,0,Hidden, Read Only, Archive,
+System, Directory.
 
 ## Function 17 : Open Directory
 
-Opens a directory for enumeration. On input: Parameters:0,1 points to the length-prefixed filename string. Only one directory at a time may be opened. If a directory is already open when this call is made, it is automatically closed. However, an open directory may make it impossible to delete the directory; so closing the directory after use is good practice.
+Opens a directory for enumeration. On input:
+Parameters:0,1 points to the length-prefixed filename string.
+Only one directory at a time may be opened. If a directory is already
+open when this call is made, it is automatically closed. However, an
+open directory may make it impossible to delete the directory; so
+closing the directory after use is good practice.
 
 ## Function 18 : Read Directory
 
-Reads an item from the currently open directory. On input: Parameters:0,1 points to a length-prefixed buffer for returning the filename. Parameters:0,1 is unchanged, but the buffer is updated to contain the length-prefixed filename (without any leading path); Parameters:2..5 contains the length of the file; Parameter:6 contains the file attributes, as described by Function 3,16 "File Stat". If there are no more items to read, this call fails and an error is flagged.
+Reads an item from the currently open directory. On input:
+Parameters:0,1 points to a length-prefixed buffer for returning the filename.
+Parameters:0,1 is unchanged, but the buffer is updated to contain the
+length-prefixed filename (without any leading path);
+Parameters:2..5 contains the length of the file;
+Parameter:6 contains the file attributes, as described by Function 3,16 "File Stat".
+If there are no more items to read, this call fails and an error is flagged.
 
 ## Function 19 : Close Directory
 
@@ -208,15 +310,24 @@ Closes any directory opened previously by Function 3,17 "Open Directory".
 
 ## Function 20 : Copy File
 
-Copies a file. On input: Parameters:0,1 points to the length-prefixed old filename; Parameters:2,3 points to the length-prefixed new filename. Only single files may be copied, not directories.
+Copies a file. On input:
+Parameters:0,1 points to the length-prefixed old filename;
+Parameters:2,3 points to the length-prefixed new filename.
+Only single files may be copied, not directories.
 
 ## Function 21 : Set file attributes
 
-Sets the attributes for a file. On input: Parameters:0,1 points to the length-prefixed filename; Parameter:2 is the attribute bitfield. (See Stat File for details.) The directory bit cannot be changed. Obviously.
+Sets the attributes for a file. On input:
+Parameters:0,1 points to the length-prefixed filename;
+Parameter:2 is the attribute bitfield. (See Stat File for details.)
+The directory bit cannot be changed. Obviously.
 
 ## Function 32 : List Filtered
 
-Prints a filtered file listing of the current directory to the console. On input: Parameters:0,1 points to the filename search string. Files will only be shown if the name contains the search string (ie: a substring match).
+Prints a filtered file listing of the current directory to the console. On input:
+Parameters:0,1 points to the filename search string.
+Files will only be shown if the name contains the search string (ie: a
+substring match).
 
 \newpage
 
@@ -248,7 +359,8 @@ Register1 := Register 1 mod Register2
 
 ## Function 6 : Compare
 
-Parameter:0 := Register 1 compare Register2 : returns $FF, 0, 1 for less equal and greater. Note: float comparison is approximate because of rounding.
+Parameter:0 := Register 1 compare Register2 : returns $FF, 0, 1 for less equal and greater.
+Note: float comparison is approximate because of rounding.
 
 ## Function 16 : Negate
 
@@ -324,43 +436,66 @@ Sets the use of degrees (the default) when non zero, radians when zero.
 
 ## Function 1 : Set Defaults
 
-Configure the global graphics system settings. Not all parameters are relevant for all graphics commands; but all parameters will be set by this command. So mind their values. Refer to Section "Graphics Settings" for details. The parameters are And, Or, Fill Flag, Extent, and Flip. Bit 0 of flip sets the horizontal flip, Bit 1 sets the vertical flip.
+Configure the global graphics system settings.
+Not all parameters are relevant for all graphics commands;
+but all parameters will be set by this command. So mind their values.
+Refer to Section "Graphics Settings" for details.
+The parameters are And, Or, Fill Flag, Extent, and Flip. Bit 0 of flip
+sets the horizontal flip, Bit 1 sets the vertical flip.
 
 ## Function 2 : Draw Line
 
-Draw a line between the screen coordinates specified in  Parameters:0,1,Parameters:2,3 (begin X,Y) and Parameters:4,5,Parameters:6,7 (end X,Y).
+Draw a line between the screen coordinates specified
+in  Parameters:0,1,Parameters:2,3 (begin X,Y)
+and Parameters:4,5,Parameters:6,7 (end X,Y).
 
 ## Function 3 : Draw Rectangle
 
-Draw a rectangle spanning the screen coordinates specified in  Parameters:0,1,Parameters:2,3 (corner X,Y) and Parameters:4,5,Parameters:6,7 (opposite corner X,Y).
+Draw a rectangle spanning the screen coordinates specified
+in  Parameters:0,1,Parameters:2,3 (corner X,Y)
+and Parameters:4,5,Parameters:6,7 (opposite corner X,Y).
 
 ## Function 4 : Draw Ellipse
 
-Draw an ellipse spanning the screen coordinates specified in  Parameters:0,1,Parameters:2,3 (corner  X,Y) and Parameters:4,5,Parameters:6,7 (opposite corner X,Y).
+Draw an ellipse spanning the screen coordinates specified
+in  Parameters:0,1,Parameters:2,3 (corner  X,Y)
+and Parameters:4,5,Parameters:6,7 (opposite corner X,Y).
 
 ## Function 5 : Draw Pixel
 
-Draw a single pixel at the screen coordinates specified in Parameters:0,1,Parameters:2,3 (X,Y).
+Draw a single pixel at the screen coordinates specified
+in Parameters:0,1,Parameters:2,3 (X,Y).
 
 ## Function 6 : Draw Text
 
-Draw the length-prefixed string of text stored at the memory location specified in Parameters:4,5 at the screen character cell specified in Parameters:0,1,Parameters:2,3 (X,Y).
+Draw the length-prefixed string of text stored
+at the memory location specified in Parameters:4,5
+at the screen character cell specified in Parameters:0,1,Parameters:2,3 (X,Y).
 
 ## Function 7 : Draw Image
 
-Draw the image with image ID in Parameter:4 at the screen coordinates Parameters:0,1,Parameters:2,3 (X,Y). The extent and flip settings influence this command.
+Draw the image with image ID in Parameter:4
+at the screen coordinates Parameters:0,1,Parameters:2,3 (X,Y).
+The extent and flip settings influence this command.
 
 ## Function 8 : Draw Tilemap
 
-Draw the current tilemap at the screen coordinates specified in Parameters:0,1,Parameters:2,3 (top-left X,Y) and Parameters:4,5,Parameters:6,7 (bottom-right X,Y) using current graphics settings.
+Draw the current tilemap at the screen coordinates specified
+in Parameters:0,1,Parameters:2,3 (top-left X,Y)
+and Parameters:4,5,Parameters:6,7 (bottom-right X,Y)
+using current graphics settings.
 
 ## Function 32 : Set Palette
 
-Set the palette colour at the index spcified in Parameter:0 to the values in Parameter:1,Parameter:2,Parameter:3 (RGB).
+Set the palette colour at the index spcified in Parameter:0
+to the values in Parameter:1,Parameter:2,Parameter:3 (RGB).
 
 ## Function 33 : Read Pixel
 
-Read a single pixel at the screen coordinates specified in Parameters:0,1,Parameters:2,3 (X,Y). When the routine completes, the result will be in Parameter:0. If sprites are in use, this will be the background only (0..15), if sprites are not in use it may return (0..255)
+Read a single pixel at the screen coordinates specified
+in Parameters:0,1,Parameters:2,3 (X,Y).
+When the routine completes, the result will be in Parameter:0. If sprites are in use, this will be the
+background only (0..15), if sprites are not in use it may return (0..255)
 
 ## Function 34 : Reset Palette
 
@@ -368,39 +503,53 @@ Reset the palette to the defaults.
 
 ## Function 35 : Set Tilemap
 
-Set the current tilemap. Parameters:0,1 is the memory address of the tilemap, and Parameters:2,3,Parameters:4,5 (X,Y) specifies the offset into the tilemap, in units of pixels, of the top-left pixel of the tile.
+Set the current tilemap.
+Parameters:0,1 is the memory address of the tilemap,
+and Parameters:2,3,Parameters:4,5 (X,Y) specifies the offset into the tilemap,
+in units of pixels, of the top-left pixel of the tile.
 
 ## Function 36 : Read Sprite Pixel
 
-Read Pixel from the sprite layer at the screen coordinates specified in Parameters:0,1,Parameters:2,3 (X,Y). When the routine completes, the result will be in Parameter:0. Refer to Section "Pixel Colors" for details.
+Read Pixel from the sprite layer at the screen coordinates
+specified in Parameters:0,1,Parameters:2,3 (X,Y).
+When the routine completes, the result will be in Parameter:0.
+Refer to Section "Pixel Colors" for details.
 
 ## Function 37 : Frame Count
 
-Deposit into Parameters:0..3, the number of v-blanks (full screen redraws) which have occurred since power-on. This is updated at the start of each v-blank period.
+Deposit into Parameters:0..3,
+the number of v-blanks (full screen redraws) which have occurred since power-on.
+This is updated at the start of each v-blank period.
 
 ## Function 38 : Get Palette
 
-Get the palette colour at the index spcified in Parameter:0. Values are returned in Parameter:1,Parameter:2,Parameter:3 (RGB).
+Get the palette colour at the index spcified in Parameter:0.
+Values are returned in Parameter:1,Parameter:2,Parameter:3 (RGB).
 
 ## Function 39 : Write Pixel
 
-Write Pixel index Parameter:4 to the screen coordinate specified in Parameters:0,1,Parameters:2,3 (X,Y).
+Write Pixel index Parameter:4 to the screen coordinate specified in
+Parameters:0,1,Parameters:2,3 (X,Y).
 
 ## Function 64 : Set Color
 
-Set Color Sets the current drawing colour to Parameter:0
+Set Color
+Sets the current drawing colour to Parameter:0
 
 ## Function 65 : Set Solid Flag
 
-Set Solid Flag Sets the solid flag to Parameter:0, which indicates either solid fill (for shapes) or solid background (for images and fonts)
+Set Solid Flag
+Sets the solid flag to Parameter:0, which indicates either solid fill (for shapes) or solid background (for images and fonts)
 
 ## Function 66 : Set Draw Size
 
-Set Draw Size Sets the drawing scale for images and fonts to Parameter:0
+Set Draw Size
+Sets the drawing scale for images and fonts to Parameter:0
 
 ## Function 67 : Set Flip Bits
 
-Set Flip Bits Sets the flip bits for drawing images. Bit 0 set causes a horizontal flip, bit 1 set causes a vertical flip.
+Set Flip Bits
+Sets the flip bits for drawing images. Bit 0 set causes a horizontal flip, bit 1 set causes a vertical flip.
 
 \newpage
 
@@ -412,7 +561,10 @@ Reset the sprite system.
 
 ## Function 2 : Sprite Set
 
-Set or update the sprite specified in Parameter:0. The parameters are : Sprite Number, X Low, X High, Y Low, Y High, Image, Flip and Anchor and Flags Bit 0 of flags specifies 32 bit sprites. Values that are $80 or $8080 are not updated.
+Set or update the sprite specified in Parameter:0.
+The parameters are : Sprite Number, X Low, X High, Y Low, Y High, Image, Flip and Anchor and Flags
+Bit 0 of flags specifies 32 bit sprites.
+Values that are $80 or $8080 are not updated.
 
 ## Function 3 : Sprite Hide
 
@@ -420,11 +572,14 @@ Hide the sprite specified in Parameter:0.
 
 ## Function 4 : Sprite Collision
 
-Parameter:0 is non-zero if the distance is less than or equal to Parameter:2 between the center of the sprite with index specified in Parameter:0 and the center of the sprite with index specified in Parameter:1 .
+Parameter:0 is non-zero if the distance is less than or equal to Parameter:2
+between the center of the sprite with index specified in Parameter:0
+and the center of the sprite with index specified in Parameter:1 .
 
 ## Function 5 : Sprite Position
 
-Deposit into Parameters:1..4, the screen coordinates of the sprite with the index specified in Parameter:0.
+Deposit into Parameters:1..4, the screen coordinates of the sprite
+with the index specified in Parameter:0.
 
 \newpage
 
@@ -432,15 +587,27 @@ Deposit into Parameters:1..4, the screen coordinates of the sprite with the inde
 
 ## Function 1 : Read Default Controller
 
-This reads the status of the base controller into Parameter:0, and is a compatibility API call. \newline  The base controller is the keyboard keys (these are WASD+OPKL or Arrow Keys+ZXCV) or the gamepad controller buttons. Either works. The 8 bits of the returned byte are the following buttons, most significant first : Y X B A Down Up Right Left
+This reads the status of the base controller into Parameter:0, and is a compatibility
+API call.
+\newline
+
+The base controller is the keyboard keys (these are WASD+OPKL or Arrow Keys+ZXCV) or the
+gamepad controller buttons. Either works.
+The 8 bits of the returned byte are the following buttons, most significant first :
+Y X B A Down Up Right Left
 
 ## Function 2 : Read Controller Count
 
-This returns the number of game controllers plugged in to the USB System into Parameter:0. This does not include the keyboard based controller, only physical controller hardware.
+This returns the number of game controllers plugged in to the USB System into Parameter:0. This does not include the
+keyboard based controller, only physical controller hardware.
 
 ## Function 3 : Read Controller
 
-This returns a specific controller status. Controller 0 is the keyboard controller, Controllers 1 upwards are those physical USB devices. This returns a 32 bit value in Parameters:0..3 which currently is compatible with function 1, but allows for expansion. The 8 bits of the returned byte are the following buttons, most significant first : Y X B A Down Up Right Left
+This returns a specific controller status. Controller 0 is the keyboard controller, Controllers 1 upwards are
+those physical USB devices.
+This returns a 32 bit value in Parameters:0..3 which currently is compatible with function 1, but allows for expansion.
+The 8 bits of the returned byte are the following buttons, most significant first :
+Y X B A Down Up Right Left
 
 \newpage
 
@@ -448,7 +615,8 @@ This returns a specific controller status. Controller 0 is the keyboard controll
 
 ## Function 1 : Reset Sound
 
-Reset the sound system. This empties all channel queues and silences all channels immediately.
+Reset the sound system.
+This empties all channel queues and silences all channels immediately.
 
 ## Function 2 : Reset Channel
 
@@ -460,15 +628,20 @@ Play the startup beep immediately.
 
 ## Function 4 : Queue Sound
 
-Queue a sound. Refer to Section \#\ref{sound} "Sound" for details. The parameters are : Channel, Frequency Low, Frequency High, Duration Low, Duration High, Slide Low, Slide High and Source.
+Queue a sound. Refer to Section \#\ref{sound} "Sound" for details.
+The parameters are : Channel, Frequency Low, Frequency High,
+Duration Low, Duration High, Slide Low, Slide High and Source.
 
 ## Function 5 : Play Sound
 
-Play the sound effect specified in Parameter:1 on the channel specified in Parameter:0 immediately, clearing the channel queue.
+Play the sound effect specified in Parameter:1
+on the channel specified in Parameter:0 immediately, clearing the channel queue.
 
 ## Function 6 : Sound Status
 
-Deposit in Parameter:0 the number of notes outstanding before silence in the queue of the channel specified in Parameter:0, including the current playing sound, if any.
+Deposit in Parameter:0 the number of notes outstanding before silence
+in the queue of the channel specified in Parameter:0,
+including the current playing sound, if any.
 
 \newpage
 
@@ -476,7 +649,10 @@ Deposit in Parameter:0 the number of notes outstanding before silence in the que
 
 ## Function 1 : Turtle Initialise
 
-Initialise the turtle graphics system. Parameter:0 is the sprite number to use for the turtle, as the turtle graphics system “adopts” one of the sprites. The icon is not currently re-definable, and initially the turtle is hidden.
+Initialise the turtle graphics system.
+Parameter:0 is the sprite number to use for the turtle,
+as the turtle graphics system “adopts” one of the sprites.
+The icon is not currently re-definable, and initially the turtle is hidden.
 
 ## Function 2 : Turtle Turn
 
@@ -484,7 +660,8 @@ Turn the turtle right by Parameter:0,1 degrees. Show if hidden. To turn left, tu
 
 ## Function 3 : Turtle Move
 
-Move the turtle forward by Parameter:0,1 degrees, drawing in colour Parameter:2, pen down flag in Parameter:3. Show if hidden.
+Move the turtle forward by Parameter:0,1 degrees, drawing in colour Parameter:2,
+pen down flag in Parameter:3. Show if hidden.
 
 ## Function 4 : Turtle Hide
 
@@ -500,63 +677,85 @@ Move the turtle to the home position (in the center, pointing upward).
 
 ## Function 1 : UExt Initialise
 
-Initialise the UExt I/O system. This resets the IO system to its default state, where all UEXT pins are I/O pins, inputs and enabled.
+Initialise the UExt I/O system.
+This resets the IO system to its default state, where all UEXT pins are I/O pins,
+inputs and enabled.
 
 ## Function 2 : Write GPIO
 
-This copies the value Parameter:1 to the output latch for UEXT pin Parameter:0. This will only display on the output pin if it is enabled, and its direction is set to "Output" direction.
+This copies the value Parameter:1 to the output latch for UEXT pin Parameter:0.
+This will only display on the output pin if it is enabled,
+and its direction is set to "Output" direction.
 
 ## Function 3 : Read GPIO
 
-If the pin is set to "Input" direction, reads the level on pin on UEXT port Parameter:0. If it is set to "Output" direction, reads the output latch for pin on UEXT port Parameter:0. If the read is successful, the result will be in Parameter:0.
+If the pin is set to "Input" direction, reads the level on pin on UEXT port Parameter:0.
+If it is set to "Output" direction, reads the output latch for pin on UEXT port Parameter:0.
+If the read is successful, the result will be in Parameter:0.
 
 ## Function 4 : Set Port Direction
 
-Set the port direction for UEXT Port Parameter:0 to the value in Parameter:1. This can be $01 (Input), $02 (Output), or $03 (Analogue Input).
+Set the port direction for UEXT Port Parameter:0 to the value in Parameter:1.
+This can be $01 (Input), $02 (Output), or $03 (Analogue Input).
 
 ## Function 5 : Write I2C
 
-Write to I2C Device Parameter:0, Register Parameter:1, value Parameter:2. No error is flagged if the device is not present.
+Write to I2C Device Parameter:0, Register Parameter:1, value Parameter:2.
+No error is flagged if the device is not present.
 
 ## Function 6 : Read I2C
 
-Read from I2C Device Parameter:0, Register Parameter:1. If the read is successful, the result will be in Parameter:0. If the device is not present, this will flag an error. Use FUNCTION 10,2 first, to check for its presence.
+Read from I2C Device Parameter:0, Register Parameter:1.
+If the read is successful, the result will be in Parameter:0.
+If the device is not present, this will flag an error.
+Use FUNCTION 10,2 first, to check for its presence.
 
 ## Function 7 : Read Analog
 
-Read the analogue value on UEXT Pin Parameter:0. This has to be set to analogue type to work. Returns a value from 0..4095 stored in Parameters:0,1, which represents an input value of 0 to 3.3 volts.
+Read the analogue value on UEXT Pin Parameter:0.
+This has to be set to analogue type to work.
+Returns a value from 0..4095 stored in Parameters:0,1,
+which represents an input value of 0 to 3.3 volts.
 
 ## Function 8 : I2C Status
 
-Try to read from I2C Device Parameter:0. If present, then Parameter:0 will contain a non-zero value.
+Try to read from I2C Device Parameter:0.
+If present, then Parameter:0 will contain a non-zero value.
 
 ## Function 9 : Read I2C Block
 
-Try to read a block of memory from I2C Device Parameter:0 into memory at Parameters:1,2, length Parameters:3,4.
+Try to read a block of memory from I2C Device Parameter:0 into memory
+at Parameters:1,2, length Parameters:3,4.
 
 ## Function 10 : Write I2C Block
 
-Try to write a block of memory to I2C Device Parameter:0 from memory at Parameters:1,2, length Parameters:3,4.
+Try to write a block of memory to I2C Device Parameter:0 from memory
+at Parameters:1,2, length Parameters:3,4.
 
 ## Function 11 : Read SPI Block
 
-Try to read a block of memory from SPI Device into memory at Parameters:1,2, length Parameters:3,4.
+Try to read a block of memory from SPI Device into memory
+at Parameters:1,2, length Parameters:3,4.
 
 ## Function 12 : Write SPI Block
 
-Try to write a block of memory to SPI Device from memory at Parameters:1,2, length Parameters:3,4.
+Try to write a block of memory to SPI Device from memory
+at Parameters:1,2, length Parameters:3,4.
 
 ## Function 13 : Read UART Block
 
-Try to read a block of memory from UART into memory at Parameters:1,2, length Parameters:3,4. This can fail with a timeout.
+Try to read a block of memory from UART into memory
+at Parameters:1,2, length Parameters:3,4. This can fail with a timeout.
 
 ## Function 14 : Write UART Block
 
-Try to write a block of memory to UART from memory at Parameters:1,2, length Parameters:3,4.
+Try to write a block of memory to UART from memory
+at Parameters:1,2, length Parameters:3,4.
 
 ## Function 15 : Set UART Speed and Protocol
 
-Set the Baud Rate and Serial Protocol for the UART interface. The baud rate is in Parameters:0..3 and the protocol number is Parameter:4. Currently only 8N1 is supported, this is protocol 0.
+Set the Baud Rate and Serial Protocol for the UART interface. The baud rate is in Parameters:0..3
+and the protocol number is Parameter:4. Currently only 8N1 is supported, this is protocol 0.
 
 ## Function 16 : Write byte to UART
 
@@ -584,7 +783,9 @@ Shows or hides the mouse cursor depending on the Parameter:0
 
 ## Function 3 : Get mouse state
 
-Returns the mouse position (screen pixel, unsigned) in x Parameters:0,1 and y Parameters:2,3, buttonstate in Parameter:4 (button 1 is 0x1, button 2 0x2 etc., set when pressed), scrollwheelstate in Parameter:5 as uint8 which changes according to scrolls.
+Returns the mouse position (screen pixel, unsigned) in x Parameters:0,1 and y Parameters:2,3,
+buttonstate in Parameter:4 (button 1 is 0x1, button 2 0x2 etc., set when pressed),
+scrollwheelstate in Parameter:5 as uint8 which changes according to scrolls.
 
 ## Function 4 : Test mouse present
 
@@ -600,15 +801,67 @@ Select a mouse cursor in Parameter:0 ; returns error status if the cursor is not
 
 ## Function 1 : Blitter Busy
 
-Returns a non zero value in Parameter:1 if the blitter/DMA system is currently transferring data, used to check availability and transfer completion.
+Returns a non zero value in Parameter:1 if the blitter/DMA system is currently transferring data, used to check availability
+and transfer completion.
 
 ## Function 2 : Simple Blit Copy
 
-Copy Parameters:6,7 bytes of internal memory from Parameter:0:Parameters:1,2 to Parameter:3:Parameters:4,5. Sets error flag if the transfer is not possible (e.g. illegal write addresses). The upper 8 bits of the address are : 6502 RAM (00) VideoRAM (80,81) Graphics RAM(90)
+Copy Parameters:6,7 bytes of internal memory from Parameter:0:Parameters:1,2 to Parameter:3:Parameters:4,5. Sets error flag if the transfer is not
+possible (e.g. illegal write addresses). The upper 8 bits of the address are : 6502 RAM (00) VideoRAM (80,81) Graphics RAM(90)
 
 ## Function 3 : Complex Blit Copy
 
-Copy a rectangular area to a rectangular area (can be contiguous by size = amount of data, offset = 0, copy steps = 1) Parameter  (0) is zero. Parameters (1,2) point to the source rectangle data. Parameters (3,4) point to the target rectangle data. These are as follows 0-3     24 bit address to copy from/to (address is address:page:0) 4-7     Step size (e.g. if copying 32 pixels, this would be 32) 8-11    Step offset (e.g. when doing screen lines this would be 320, the number of pixels per line) 12-15   Steps to copy. Activity halts when one of the steps to copy value is decremented to zero. To ignore the steps to copy in receive, set it to zero.
+Copy a source rectangular area to a destination rectangular area.
+It's oriented toward copying graphics data, but can be used as a more general-purpose memory mover.
+The source and target areas may be different formats, and the copy will convert the data on the fly.
+For example, you can expand 4bpp source graphics (two pixels per byte) into the 1 pixel per byte framebuffer.
+However, the blitting is byte-oriented. So the source width is always rounded down to the nearest full byte.
+Parameter  (0) is the blit action:
+0 = copy
+1 = copymasked - copy, but only where src is not the transparent value.
+2 = solidmasked - set target to constant solid value, but only where src is not the transparent value.
+See below for transparent/solid values.
+Parameters (1,2) address of the source rectangle data.
+Parameters (3,4) address of the target rectangle data.
+The source and target rectangle data is laid out in memory as follows:
+0-2     24 bit address to copy from/to (address is address:page:0)
+3       pad byte (must be zero)
+4-5     Stride, in bytes. This is the value to add to the address to get from one line to the next.
+Used for both source and target.
+For example:
+- if blitting to the screen, a stride of screen width (320) would get to the next line.
+- a zero source stride would repeat a single line for the whole copy.
+- A negative target stride would draw from the bottom upward.
+6       data format
+0: bytes. Supported for both source and target.
+1: pairs of 4-bit values (nibbles). Source only.
+2: 8 single-bit values. Source only.
+3: high nibble. Target only.
+4: low nibble. Target only.
+7       A constant to use as the "transparent" value for BLTACT_MASK and BLTACT_SOLID. Source only. Not used in target.
+8       A constant to use as the "solid" value for BLTACT_SOLID. Source only. Not used in target.
+9       Height. The number of lines to copy.
+Source only. Not used in target.
+The copy is driven by the source height.
+10-11   Width. The number of values to copy for each line.
+Source only. Not used in target.
+The copy is driven by the source width.
+
+## Function 4 : Blit Image
+
+Blits an image from memory onto the screen. The image will be clipped,
+so it's safe to blit partly (or fully) offscreen-images.
+Parameter  (0) is the blit action (see function 3, Complex Blit):
+Parameters (1,2) address of the source rectangle data.
+Parameters (3,4) x pixel coordinate on screen (signed 16 bit)
+Parameters (5,6) y pixel coordinate on screen (signed 16 bit)
+Parameter  (7) destination format, determines how framebuffer will be written:
+0: write to whole byte.
+1: unsupported
+2: unsupported
+3: write to high nibble only.
+4: write to low nibble only.
+NOTE: clipping operates at byte resolution on the source data. So, for example, if you blit a 1-bit image (format 2) to an x-position of -2, then the whole first byte will be skipped leaving 6 empty pixels on the left. Same happens on the right - either the whole source byte is used, or it'll be skipped.
 
 \newpage
 
@@ -620,7 +873,8 @@ Initialises the editor
 
 ## Function 2 : Reenter the Editor
 
-Re-enters the system editor. Returns the function required for call out, the editors sort of 'call backs' - see editor specification.
+Re-enters the system editor. Returns the function required for call out, the editors
+sort of 'call backs' - see editor specification.
 
 \newpage
 

--- a/firmware/common/config/system/group12_blitter.inc
+++ b/firmware/common/config/system/group12_blitter.inc
@@ -12,7 +12,7 @@
 
 // ***************************************************************************************
 //
-//                                  Group 10 (UExt)
+//                                  Group 12 (Blitter)
 //
 // ***************************************************************************************
 
@@ -36,17 +36,76 @@ GROUP 12 Blitter
         *DERROR = BLTComplexCopy(DPARAMS[0],DSPGetInt16(DCOMMAND,5),DSPGetInt16(DCOMMAND,7));
 
     DOCUMENTATION
-        Copy a rectangular area to a rectangular area (can be contiguous by size = amount of data, offset = 0, copy steps = 1)
-            Parameter  (0) is zero.
-            Parameters (1,2) point to the source rectangle data.
-            Parameters (3,4) point to the target rectangle data.
+        Copy a source rectangular area to a destination rectangular area.
+        It's oriented toward copying graphics data, but can be used as a more general-purpose memory mover.
+        The source and target areas may be different formats, and the copy will convert the data on the fly.
+        For example, you can expand 4bpp source graphics (two pixels per byte) into the 1 pixel per byte framebuffer.
+        However, the blitting is byte-oriented. So the source width is always rounded down to the nearest full byte.
 
-            These are as follows
-                0-3     24 bit address to copy from/to (address is address:page:0)
-                4-7     Step size (e.g. if copying 32 pixels, this would be 32)
-                8-11    Step offset (e.g. when doing screen lines this would be 320, the number of pixels per line)     
-                12-15   Steps to copy.
+            Parameter  (0) is the blit action:
 
-            Activity halts when one of the steps to copy value is decremented to zero. To ignore the steps to copy in receive,
-            set it to zero.
+                           0 = copy
+                           1 = copymasked - copy, but only where src is not the transparent value.
+                           2 = solidmasked - set target to constant solid value, but only where src is not the transparent value.
+                           See below for transparent/solid values.
+
+            Parameters (1,2) address of the source rectangle data.
+
+            Parameters (3,4) address of the target rectangle data.
+
+            The source and target rectangle data is laid out in memory as follows:
+
+                0-2     24 bit address to copy from/to (address is address:page:0)
+
+                3       pad byte (must be zero)
+
+                4-5     Stride, in bytes. This is the value to add to the address to get from one line to the next.
+                        Used for both source and target.
+                        For example:
+                        - if blitting to the screen, a stride of screen width (320) would get to the next line.
+                        - a zero source stride would repeat a single line for the whole copy.
+                        - A negative target stride would draw from the bottom upward.
+
+                6       data format
+                        0: bytes. Supported for both source and target.
+                        1: pairs of 4-bit values (nibbles). Source only.
+                        2: 8 single-bit values. Source only.
+                        3: high nibble. Target only.
+                        4: low nibble. Target only.
+
+                7       A constant to use as the "transparent" value for BLTACT_MASK and BLTACT_SOLID. Source only. Not used in target.
+
+                8       A constant to use as the "solid" value for BLTACT_SOLID. Source only. Not used in target.
+
+                9       Height. The number of lines to copy.
+                        Source only. Not used in target.
+                        The copy is driven by the source height.
+
+                10-11   Width. The number of values to copy for each line.
+                        Source only. Not used in target.
+                        The copy is driven by the source width.
+
+    FUNCTION 4 Blit Image
+        *DERROR = BLTImage(DPARAMS[0], (DPARAMS[1] | DPARAMS[2] << 8),(DPARAMS[3] | DPARAMS[4] << 8), (DPARAMS[5] | DPARAMS[6] << 8), DPARAMS[7]);
+
+    DOCUMENTATION
+        Blits an image from memory onto the screen. The image will be clipped,
+        so it's safe to blit partly (or fully) offscreen-images.
+
+            Parameter  (0) is the blit action (see function 3, Complex Blit):
+
+            Parameters (1,2) address of the source rectangle data.
+
+            Parameters (3,4) x pixel coordinate on screen (signed 16 bit)
+
+            Parameters (5,6) y pixel coordinate on screen (signed 16 bit)
+
+            Parameter  (7) destination format, determines how framebuffer will be written:
+                        0: write to whole byte.
+                        1: unsupported
+                        2: unsupported
+                        3: write to high nibble only.
+                        4: write to low nibble only.
+
+        NOTE: clipping operates at byte resolution on the source data. So, for example, if you blit a 1-bit image (format 2) to an x-position of -2, then the whole first byte will be skipped leaving 6 empty pixels on the left. Same happens on the right - either the whole source byte is used, or it'll be skipped.
 

--- a/firmware/common/include/interface/blitter.h
+++ b/firmware/common/include/interface/blitter.h
@@ -14,17 +14,37 @@
 #define _BLITTER_H
 
 struct BlitterArea {
-	uint16_t 	address;
-	uint8_t 	page,_filler;
-	uint32_t  	stepSize;
-	uint32_t  	stepOffset;
-	uint32_t  	stepCount;
+	uint16_t	address;
+	uint8_t		page;
+    uint8_t     padding;     // unused. Should be zero.
+	int16_t		stride;		 // Number of bytes between start of each line in memory (in bytes).
+	uint8_t		format;      // one of BLTFMT_*
+    // Everything below here is ignored for target.
+	uint8_t		transparent; // transparent value in src, for BLTACT_MASK and BLTACT_SOLID.
+	uint8_t		solid;	 	 // constant value for BLTACT_SOLID.
+	uint8_t  	height;		 // Number of lines.
+	uint16_t  	width;		 // Size of line, in src units.
 };
 
-uint8_t BLTSimpleCopy(uint8_t pageFrom,uint16_t addressFrom, uint8_t pageTo, uint16_t addressTo, uint16_t transferSize);
-uint8_t BLTComplexCopy(uint8_t action,uint16_t aSource,uint16_t aTarget);
-#endif
+// Format types for BlitterArea.format field
+#define BLTFMT_BYTE 0		// whole byte
+#define BLTFMT_PAIR 1		// 2 4-bit values, aka nibbles (src only)
+#define BLTFMT_BITS 2		// 8 1-bit values (src only)
+#define BLTFMT_HIGH 3		// High nibble (target only)
+#define BLTFMT_LOW  4		// Low nibble (target only)
 
+uint8_t BLTSimpleCopy(uint8_t pageFrom,uint16_t addressFrom, uint8_t pageTo, uint16_t addressTo, uint16_t transferSize);
+
+// Values for BLTComplexCopy and BLTImage action params
+#define BLTACT_COPY 0		// Straight rectangle copy
+#define BLTACT_MASK 1		// Copy, but only where src != srcarea.transparent
+#define BLTACT_SOLID 2		// Fill with constant srcarea.solid value, but only where src != srcarea.transparent
+
+uint8_t BLTComplexCopy(uint8_t action,uint16_t aSource,uint16_t aTarget);
+
+uint8_t BLTImage(uint8_t action, uint16_t sourceArea, int16_t x, int16_t y, uint8_t destFmt);
+
+#endif
 // ***************************************************************************************
 //
 //		Date 		Revision

--- a/firmware/common/scripts/makedispatch.py
+++ b/firmware/common/scripts/makedispatch.py
@@ -216,7 +216,7 @@ class DispatchAPI(object):
 		 		fn_name  = function.funcName
 		 		fn_table_tex.append("## Function {0} : {1}".format(fn_id,fn_name))
 		 		docLines = function.docLines if function.docLines[-1] else function.docLines[0:-2]
-		 		desc = " ".join(docLines)
+		 		desc = "\n".join(docLines)
 		 		fn_table_tex.append(desc)
 			fn_table_tex.append("\\newpage")
 

--- a/firmware/common/sources/interface/blitter.cpp
+++ b/firmware/common/sources/interface/blitter.cpp
@@ -74,12 +74,522 @@ void _BLTAddAddress(struct BlitterArea *ba,uint32_t add) {
 // ***************************************************************************************
 
 void _BLTLoadBlitterAreaObject(uint16_t addr,struct BlitterArea *b) {
-	b->address = cpuMemory[addr]+(cpuMemory[addr+1] << 8);
+	b->address = cpuMemory[addr] + (cpuMemory[addr+1] << 8);
 	b->page = cpuMemory[addr+2];
-	b->stepSize = cpuMemory[addr+4]+(cpuMemory[addr+5] << 8)+(cpuMemory[addr+6] << 16);
-	b->stepOffset = cpuMemory[addr+8]+(cpuMemory[addr+9] << 8)+(cpuMemory[addr+10] << 16);
-	b->stepCount = cpuMemory[addr+12]+(cpuMemory[addr+13] << 8)+(cpuMemory[addr+14] << 16);
+	// 1 byte of padding
+	b->stride = cpuMemory[addr+4] + (cpuMemory[addr+5] << 8);
+	b->format = cpuMemory[addr+6];
+	// The rest are source-only.
+	b->transparent = cpuMemory[addr+7];
+	b->solid = cpuMemory[addr+8];
+	b->height = cpuMemory[addr+9];
+	b->width = cpuMemory[addr+10] + (cpuMemory[addr+11] << 8);
 }
+
+// ***************************************************************************************
+//
+//					BLTComplexCopy() line helpers: straight copy
+//
+// ***************************************************************************************
+
+// Definition for our line-copy routines.
+typedef void (*copyFn)(uint8_t *, const uint8_t *, size_t );
+
+// Copy src to target, whole bytes.
+static void copy_ByteToByte(uint8_t *tgt, const uint8_t *src, size_t n) {
+	memmove(tgt, src, n);
+}
+
+//  Copy src to target low nibble (target high nibble is unchanged).
+static void copy_ByteToLow(uint8_t *tgt, const uint8_t *src, size_t n) {
+	while(n > 0) {
+		*tgt = (*tgt & 0xF0) | (*src & 0x0F);
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+//  Copy src to target high nibble (target low nibble is unchanged).
+static void copy_ByteToHigh(uint8_t *tgt, const uint8_t *src, size_t n) {
+	while(n > 0) {
+		*tgt = (*tgt & 0x0F) | (*src << 4);
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+// Expand src nibbles into consecutive bytes in target (high nibbles of target will be zeroed).
+static void copy_PairToByte(uint8_t *tgt, const uint8_t *src, size_t n) {
+	n = n / 2;	// 2 nibbles per byte.
+	while(n > 0) {
+		*tgt++ = *src >> 4;
+		*tgt++ = *src & 0x0F;
+		++src;
+		--n;
+	}
+}
+
+
+// Expand src nibbles into consecutive low nibbles in target (leaving target high nibbles unchanged).
+static void copy_PairToLow(uint8_t *tgt, const uint8_t *src, size_t n) {
+	n = n / 2;	// 2 nibbles per byte.
+	while(n > 0) {
+		*tgt = (*tgt & 0xF0) | (*src >> 4);
+		++tgt;
+		*tgt = (*tgt & 0xF0) | (*src & 0x0F);
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+// Expand src nibbles into consecutive high nibbles in target (leaving target low nibbles unchanged).
+static void copy_PairToHigh(uint8_t *tgt, const uint8_t *src, size_t n) {
+	n = n / 2;	// 2 nibbles per byte.
+	while(n > 0) {
+		*tgt = (*tgt & 0x0F) | (*src & 0xF0);
+		++tgt;
+		*tgt = (*tgt & 0x0F) | (*src << 4);
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+
+// Expand src bits into consecutive bytes in target.
+static void copy_BitsToByte(uint8_t *tgt, const uint8_t *src, size_t n) {
+	n = n / 8;	// 8 bits per byte.
+	while(n > 0) {
+		for (int i = 7; i >= 0; --i) {
+			*tgt++ = (*src >> i) & 0x01;
+		}
+		++src;
+		--n;
+	}
+}
+
+
+// Expand src bits into consecutive low nibbles in target (leaving target high nibbles unchanged).
+static void copy_BitsToLow(uint8_t *tgt, const uint8_t *src, size_t n) {
+	n = n / 8;	// 8 bits per byte.
+	while(n > 0) {
+		for (int i = 7; i >= 0; --i) {
+			*tgt = (*tgt & 0xF0) | ((*src >> i) & 0x01);
+			++tgt;
+		}
+		++src;
+		--n;
+	}
+}
+
+// Expand src bits into consecutive high nibbles in target (leaving target low nibbles unchanged).
+static void copy_BitsToHigh(uint8_t *tgt, const uint8_t *src, size_t n) {
+	n = n / 8;	// 8 bits per byte.
+	while(n > 0) {
+		for (int i = 7; i >= 0; --i) {
+			*tgt = (*tgt & 0x0F) | (((*src >> i) & 0x01) << 4);
+			++tgt;
+		}
+		++src;
+		--n;
+	}
+}
+
+
+static copyFn pickCopyFn(uint8_t srcFormat, uint8_t tgtFormat)
+{
+	switch (srcFormat) {
+		case BLTFMT_BYTE:
+			switch (tgtFormat) {
+				case BLTFMT_BYTE: return copy_ByteToByte;
+				case BLTFMT_HIGH: return copy_ByteToHigh;
+				case BLTFMT_LOW: return copy_ByteToLow;
+				default: return nullptr;
+			}
+		case BLTFMT_PAIR:
+			switch (tgtFormat) {
+				case BLTFMT_BYTE: return copy_PairToByte;
+				case BLTFMT_HIGH: return copy_PairToHigh;
+				case BLTFMT_LOW: return copy_PairToLow;
+				default: return nullptr;
+			}
+		case BLTFMT_BITS:
+			switch (tgtFormat) {
+				case BLTFMT_BYTE: return copy_BitsToByte;
+				case BLTFMT_HIGH: return copy_BitsToHigh;
+				case BLTFMT_LOW: return copy_BitsToLow;
+				default: return nullptr;
+			}
+		default: return nullptr;
+	}
+}
+
+
+// ***************************************************************************************
+//
+//			BLTComplexCopy() line helpers: copy with src masking (transparency)
+//
+// ***************************************************************************************
+
+// Definition for our masked-copy routines.
+typedef void (*copyMaskedFn)(uint8_t *, const uint8_t *, size_t, uint8_t);
+
+// Copy src to target, whole bytes.
+static void copy_masked_ByteToByte(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent) {
+	while (n>0) {
+		if (*src != transparent) {
+			*tgt = *src;
+		}
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+//  Copy src to target low nibble (target high nibble is unchanged).
+static void copy_masked_ByteToLow(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent) {
+	while(n > 0) {
+		if (*src != transparent) {
+			*tgt = (*tgt & 0xF0) | (*src & 0x0F);
+		}
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+//  Copy src to target high nibble (target low nibble is unchanged).
+static void copy_masked_ByteToHigh(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent) {
+	while(n > 0) {
+		if (*src != transparent) {
+			*tgt = (*tgt & 0x0F) | (*src << 4);
+		}
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+// Expand src nibbles into consecutive bytes in target (high nibbles of target will be zeroed).
+static void copy_masked_PairToByte(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent) {
+	n = n / 2;	// 2 nibbles per byte.
+	while(n > 0) {
+		if ((*src >> 4) != transparent) {
+			*tgt = *src >> 4;
+		}
+		++tgt;
+		if ((*src & 0x0F) != transparent) {
+			*tgt = *src & 0x0F;
+		}
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+// Expand src nibbles into consecutive low nibbles in target (leaving target high nibbles unchanged).
+static void copy_masked_PairToLow(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent) {
+	n = n / 2;	// 2 nibbles per byte.
+	while(n > 0) {
+		if ((*src >> 4) != transparent) {
+			*tgt = (*tgt & 0xF0) | (*src >> 4);
+		}
+		++tgt;
+		if ((*src & 0x0F) != transparent) {
+			*tgt = (*tgt & 0xF0) | (*src & 0x0F);
+		}
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+// Expand src nibbles into consecutive high nibbles in target (leaving target low nibbles unchanged).
+static void copy_masked_PairToHigh(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent) {
+	n = n / 2;	// 2 nibbles per byte.
+	while(n > 0) {
+		uint8_t v = *src >> 4;
+		if (v != transparent) {
+			*tgt = (*tgt & 0x0F) | (v << 4);
+		}
+		++tgt;
+		v = *src & 0x0F;
+		if (v != transparent) {
+			*tgt = (*tgt & 0x0F) | (v << 4);
+		}
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+
+// Expand src bits into consecutive bytes in target.
+static void copy_masked_BitsToByte(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent) {
+	n = n / 8;	// 8 bits per byte.
+	while(n > 0) {
+		for (int i = 7; i >= 0; --i) {
+			uint8_t v = (*src >> i) & 0x01;
+			if (v != transparent) {
+				*tgt = v;
+			}
+			++tgt;
+		}
+		++src;
+		--n;
+	}
+}
+
+
+// Expand src bits into consecutive low nibbles in target (leaving target high nibbles unchanged).
+static void copy_masked_BitsToLow(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent) {
+	n = n / 8;	// 8 bits per byte.
+	while(n > 0) {
+		for (int i = 7; i >= 0; --i) {
+			uint8_t v = (*src >> i) & 0x01;
+			if (v != transparent) {
+				*tgt = (*tgt & 0xF0) | v;
+			}
+			++tgt;
+		}
+		++src;
+		--n;
+	}
+}
+
+// Expand src bits into consecutive high nibbles in target (leaving target low nibbles unchanged).
+static void copy_masked_BitsToHigh(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent) {
+	n = n / 8;	// 8 bits per byte.
+	while(n > 0) {
+		for (int i = 7; i >= 0; --i) {
+			uint8_t v = (*src >> i) & 0x01;
+			if (v != transparent) {
+				*tgt = (*tgt & 0x0F) | (v << 4);
+			}
+			++tgt;
+		}
+		++src;
+		--n;
+	}
+}
+
+static copyMaskedFn pickCopyMaskedFn(uint8_t srcFormat, uint8_t tgtFormat)
+{
+	switch (srcFormat) {
+		case BLTFMT_BYTE:
+			switch (tgtFormat) {
+				case BLTFMT_BYTE: return copy_masked_ByteToByte;
+				case BLTFMT_HIGH: return copy_masked_ByteToHigh;
+				case BLTFMT_LOW: return copy_masked_ByteToLow;
+				default: return nullptr;
+			}
+		case BLTFMT_PAIR:
+			switch (tgtFormat) {
+				case BLTFMT_BYTE: return copy_masked_PairToByte;
+				case BLTFMT_HIGH: return copy_masked_PairToHigh;
+				case BLTFMT_LOW: return copy_masked_PairToLow;
+				default: return nullptr;
+			}
+		case BLTFMT_BITS:
+			switch (tgtFormat) {
+				case BLTFMT_BYTE: return copy_masked_BitsToByte;
+				case BLTFMT_HIGH: return copy_masked_BitsToHigh;
+				case BLTFMT_LOW: return copy_masked_BitsToLow;
+				default: return nullptr;
+			}
+		default: return nullptr;
+	}
+}
+
+
+
+// ***************************************************************************************
+//
+//					BLTComplexCopy() line helpers: solid fill with src masking
+//
+// ***************************************************************************************
+
+// Definition for our masked-solid routines.
+typedef void (*solidMaskedFn)(uint8_t *, const uint8_t *, size_t, uint8_t, uint8_t);
+
+// Copy src to target, whole bytes.
+static void solid_masked_ByteToByte(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent, uint8_t solid) {
+	while (n>0) {
+		if (*src != transparent) {
+			*tgt = solid;
+		}
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+//  Copy src to target low nibble (target high nibble is unchanged).
+static void solid_masked_ByteToLow(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent, uint8_t solid) {
+	solid &= 0x0F;
+	while(n > 0) {
+		if (*src != transparent) {
+			*tgt = (*tgt & 0xF0) | solid;
+		}
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+//  Copy src to target high nibble (target low nibble is unchanged).
+static void solid_masked_ByteToHigh(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent, uint8_t solid) {
+	solid <<= 4;
+	while(n > 0) {
+		if (*src != transparent) {
+			*tgt = (*tgt & 0x0F) | solid;
+		}
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+// Expand src nibbles into consecutive bytes in target (high nibbles of target will be zeroed).
+static void solid_masked_PairToByte(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent, uint8_t solid) {
+	solid &= 0x0F;
+	n = n / 2;	// 2 nibbles per byte.
+	while(n > 0) {
+		if ((*src >> 4) != transparent) {
+			*tgt = solid;
+		}
+		++tgt;
+		if ((*src & 0x0F) != transparent) {
+			*tgt = solid;
+		}
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+// Expand src nibbles into consecutive low nibbles in target (leaving target high nibbles unchanged).
+static void solid_masked_PairToLow(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent, uint8_t solid) {
+	solid &= 0x0F;
+	n = n / 2;	// 2 nibbles per byte.
+	while(n > 0) {
+		if ((*src >> 4) != transparent) {
+			*tgt = (*tgt & 0xF0) | solid;
+		}
+		++tgt;
+		if ((*src & 0x0F) != transparent) {
+			*tgt = (*tgt & 0xF0) | solid;
+		}
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+// Expand src nibbles into consecutive high nibbles in target (leaving target low nibbles unchanged).
+static void solid_masked_PairToHigh(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent, uint8_t solid) {
+	solid <<= 4;
+	n = n / 2;	// 2 nibbles per byte.
+	while(n > 0) {
+		uint8_t v = *src >> 4;
+		if (v != transparent) {
+			*tgt = (*tgt & 0x0F) | solid;
+		}
+		++tgt;
+		v = *src & 0x0F;
+		if (v != transparent) {
+			*tgt = (*tgt & 0x0F) | solid;
+		}
+		++tgt;
+		++src;
+		--n;
+	}
+}
+
+
+// Expand src bits into consecutive bytes in target.
+static void solid_masked_BitsToByte(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent, uint8_t solid) {
+	n = n / 8;	// 8 bits per byte.
+	while(n > 0) {
+		for (int i = 7; i >= 0; --i) {
+			uint8_t v = (*src >> i) & 0x01;
+			if (v != transparent) {
+				*tgt = solid;
+			}
+			++tgt;
+		}
+		++src;
+		--n;
+	}
+}
+
+
+// Expand src bits into consecutive low nibbles in target (leaving target high nibbles unchanged).
+static void solid_masked_BitsToLow(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent, uint8_t solid) {
+	solid &= 0x0F;
+	n = n / 8;	// 8 bits per byte.
+	while(n > 0) {
+		for (int i = 7; i >= 0; --i) {
+			uint8_t v = (*src >> i) & 0x01;
+			if (v != transparent) {
+				*tgt = (*tgt & 0xF0) | solid;
+			}
+			++tgt;
+		}
+		++src;
+		--n;
+	}
+}
+
+// Expand src bits into consecutive high nibbles in target (leaving target low nibbles unchanged).
+static void solid_masked_BitsToHigh(uint8_t *tgt, const uint8_t *src, size_t n, uint8_t transparent, uint8_t solid) {
+	solid <<= 4;
+	n = n / 8;	// 8 bits per byte.
+	while(n > 0) {
+		for (int i = 7; i >= 0; --i) {
+			uint8_t v = (*src >> i) & 0x01;
+			if (v != transparent) {
+				*tgt = (*tgt & 0x0F) | solid;
+			}
+			++tgt;
+		}
+		++src;
+		--n;
+	}
+}
+
+static solidMaskedFn pickSolidMaskedFn(uint8_t srcFormat, uint8_t tgtFormat)
+{
+	switch (srcFormat) {
+		case BLTFMT_BYTE:
+			switch (tgtFormat) {
+				case BLTFMT_BYTE: return solid_masked_ByteToByte;
+				case BLTFMT_HIGH: return solid_masked_ByteToHigh;
+				case BLTFMT_LOW: return solid_masked_ByteToLow;
+				default: return nullptr;
+			}
+		case BLTFMT_PAIR:
+			switch (tgtFormat) {
+				case BLTFMT_BYTE: return solid_masked_PairToByte;
+				case BLTFMT_HIGH: return solid_masked_PairToHigh;
+				case BLTFMT_LOW: return solid_masked_PairToLow;
+				default: return nullptr;
+			}
+		case BLTFMT_BITS:
+			switch (tgtFormat) {
+				case BLTFMT_BYTE: return solid_masked_BitsToByte;
+				case BLTFMT_HIGH: return solid_masked_BitsToHigh;
+				case BLTFMT_LOW: return solid_masked_BitsToLow;
+				default: return nullptr;
+			}
+		default: return nullptr;
+	}
+}
+
+
 
 // ***************************************************************************************
 //
@@ -87,50 +597,170 @@ void _BLTLoadBlitterAreaObject(uint16_t addr,struct BlitterArea *b) {
 //
 // ***************************************************************************************
 
-uint8_t BLTComplexCopy(uint8_t action,uint16_t aSource,uint16_t aTarget) {
-	struct BlitterArea source,target;
+static uint8_t internalBLTComplexCopy(uint8_t action, const struct BlitterArea *source, const struct BlitterArea *target) {
 
-	_BLTLoadBlitterAreaObject(aSource,&source);
-	_BLTLoadBlitterAreaObject(aTarget,&target);
+	switch (action) {
+		case BLTACT_COPY:
+			{
+				copyFn copy = pickCopyFn(source->format, target->format);
+				if (!copy) {
+					return 1;	// Unsupported combination
+				}
 
-	uint32_t srcCount = source.stepSize;  											// Bytes to copy to/from till next step.
-	uint32_t tgtCount = target.stepSize;
+				uint8_t *src = _BLTGetRealAddress(source->page, source->address);
+				uint8_t *tgt = _BLTGetRealAddress(target->page, target->address);
+				if (src == NULL || tgt == NULL) return 1;
+				for (uint8_t l = source->height; l > 0; --l) {
+					// Process a line.
+					(*copy)(tgt, src, source->width);
+					src += source->stride;
+					tgt += target->stride;
+				}
+			}
+			break;
+		case BLTACT_MASK:
+			{
+				copyMaskedFn copyMasked = pickCopyMaskedFn(source->format, target->format);
+				if (!copyMasked) {
+					return 1;	// Unsupported combination
+				}
 
-	bool complete = source.stepCount == 0;  										// Completed if already zero.
+				uint8_t *src = _BLTGetRealAddress(source->page, source->address);
+				uint8_t *tgt = _BLTGetRealAddress(target->page, target->address);
+				if (src == NULL || tgt == NULL) return 1;
+				for (uint8_t l = source->height; l > 0; --l) {
+					(*copyMasked)(tgt, src, source->width, source->transparent);
+					src += source->stride;
+					tgt += target->stride;
+				}
+			}
+			break;
+		case BLTACT_SOLID:
+			{
+				solidMaskedFn solidMasked = pickSolidMaskedFn(source->format, target->format);
+				if (!solidMasked) {
+					return 1;	// Unsupported combination
+				}
 
-	while (!complete) {  															// Until done every source step, e.g. the whole thing has been copied.
-		//printf("SRC:%02x:%04x %d %d %d [%d]\n",source.page,(int)source.address,(int)source.stepCount,(int)source.stepSize,(int)source.stepOffset,(int)srcCount);
-		//printf("TGT:%02x:%04x %d %d %d [%d]\n",target.page,(int)target.address,(int)target.stepCount,(int)target.stepSize,(int)target.stepOffset,(int)tgtCount);
-
-		uint32_t transferSize = (srcCount < tgtCount) ? srcCount:tgtCount; 			// The amount to transfer this next time.
-		//printf("%d transfer.\n",(int)transferSize);
-		if (transferSize != 0) {
-			uint8_t *src = _BLTGetRealAddress(source.page,source.address); 			// Workout addresses
-			uint8_t *tgt = _BLTGetRealAddress(target.page,target.address);
-			if (src == NULL || tgt == NULL) return 1; 								// Bad addresses.
-			memmove(tgt,src,transferSize);  										// Do the copy
-			srcCount -= transferSize;  												// Adjust for the 'to next step'
-			tgtCount -= transferSize;
-			_BLTAddAddress(&source,transferSize);  									// Adjust addresses.
-			_BLTAddAddress(&target,transferSize);
-		}
-
-		if (srcCount == 0) {      													// Reached step on source.
-			source.stepCount--;  													// Done one fewer
-			srcCount = source.stepSize;  						 					// Rest to copy count.
-			_BLTAddAddress(&source,source.stepOffset-source.stepSize); 				// Adjust the address to the next line.
-			if (source.stepCount == 0) complete = true; 							// Transferred all the data.
-		}
-
-		if (tgtCount == 0) {      													// Reached step on target
-			target.stepCount--;  													// Done one fewer
-			tgtCount = target.stepSize;  						 					// Rest to copy count.
-			_BLTAddAddress(&target,target.stepOffset-target.stepSize); 				// Adjust the address to the next line.
-			if (target.stepCount == 0) complete = true; 							// Nowhere else to go. If zero initially goes till completed.
-		}
+				uint8_t *src = _BLTGetRealAddress(source->page, source->address);
+				uint8_t *tgt = _BLTGetRealAddress(target->page, target->address);
+				if (src == NULL || tgt == NULL) return 1;
+				for (uint8_t l = source->height; l > 0; --l) {
+					(*solidMasked)(tgt, src, source->width, source->transparent, source->solid);
+					src += source->stride;
+					tgt += target->stride;
+				}
+			}
+			break;
 	}
 	return 0;
 }
+
+uint8_t BLTComplexCopy(uint8_t action,uint16_t aSource,uint16_t aTarget) {
+	struct BlitterArea source, target;
+	_BLTLoadBlitterAreaObject(aSource,&source);
+	_BLTLoadBlitterAreaObject(aTarget,&target);
+	return internalBLTComplexCopy(action, &source, &target);
+}
+
+// ***************************************************************************************
+//
+//						Image-oriented blit function with clipping.
+//
+// ***************************************************************************************
+
+// Note: no handy width and height defines available, so we'll define them here.
+// But they should probably be somewhere else.
+#define FRAME_WIDTH 320
+#define FRAME_HEIGHT 240
+
+// Clip rectangle. Maybe it'd make sense to let user set custom clipping area, but for now
+// we'll just hardcode them here.
+#define LCLIP 0
+#define RCLIP FRAME_WIDTH
+#define TCLIP 0
+#define BCLIP FRAME_HEIGHT
+
+uint8_t BLTImage(uint8_t action, uint16_t sourceArea, int16_t x, int16_t y, uint8_t destFmt)
+{
+	struct BlitterArea src;
+	_BLTLoadBlitterAreaObject(sourceArea, &src);
+
+	// Clip against left.
+	int16_t w = src.width;
+	if (x < LCLIP) {
+		// Left-clipping is a little fiddly for sub-byte source formats.
+		// We need to round up to next byte boundary (maybe leaving
+		// up to 7 pixels missing on the left).
+		int16_t adj = (LCLIP - x);
+		switch (src.format) {
+			case BLTFMT_BYTE:
+				src.address += adj;
+				w -= adj;
+				x += adj;
+				break;
+			case BLTFMT_PAIR:
+				src.address += (adj + 1) >> 1;
+				w -= (adj + 1) & ~1;
+				x += (adj + 1) & ~1;
+				break;
+			case BLTFMT_BITS:
+				src.address += (adj + 7) >> 3;
+				w -= (adj + 7) & ~7;
+				x += (adj + 7) & ~7;
+				break;
+			default: return 1;  // bad format.
+		}
+		if (w <= 0) {
+			return 0;   // Totally off left.
+		}
+	}
+
+	// Clip against right.
+	if ((x + w) > RCLIP) {
+		// Don't worry about byte boundaries here - the blit
+		// will just skip any sub-byte data at the end of each line.
+		w -= ((x+w) - RCLIP);
+		if (w <= 0) {
+			return 0;   // Totally off right.
+		}
+	}
+	src.width = w;
+
+	int16_t h = src.height;
+	// Clip against top.
+	if (y < TCLIP) {
+		int16_t adj = TCLIP-y;
+		h -= adj;
+		if (h <= 0) {
+			return 0;   // Totally off top.
+		}
+		y += adj;
+		// Stride is in bytes.
+		src.address += adj * src.stride;
+	}
+
+	// Clip against bottom.
+	if ((y + h) > BCLIP) {
+		h -= ((y + h) - BCLIP);
+		if (h <= 0) {
+			return 0;   // Totally off bottom.
+		}
+	}
+	src.height = h;
+
+	uint32_t offset = (y * FRAME_WIDTH) + x;
+	struct BlitterArea target = {
+		.address = (uint16_t)(offset & 0xFFFF),
+		.page = (uint8_t)(0x80 + (offset >> 16)),
+		.padding = 0,
+		.stride = FRAME_WIDTH,
+		.format = destFmt,
+	};
+
+	return internalBLTComplexCopy(action, &src, &target);
+}
+
 
 // ***************************************************************************************
 //


### PR DESCRIPTION
My experiment at using the `action` param as a bitfield to allow nibble-level access to src and target data, and also to add transparency support.
It's a little silly - I think most of the combinations wouldn't be too useful, but hey.
I've only really tested the nibble-pair -> byte blitting, so there may be a couple of mistakes in the others.
Just for my own amusement really - I'm not really expecting you to merge it! But if you do want it, let me know and I'll tidy it up and update the documentation first.

