### PR TITLE
Build fixes

### DIFF
--- a/firmware/sources/CMakeLists.txt
+++ b/firmware/sources/CMakeLists.txt
@@ -61,7 +61,7 @@ target_compile_definitions(firmware
     PRIVATE PICO_FLASH_SPI_CLKDIV=4
 )
 
-pico_define_boot_stage2(firmware_boot2 ${PICO_SDK_PATH}/src/rp2_common/boot_stage2/boot2_generic_03h.S)
+pico_define_boot_stage2(firmware_boot2 ${PICO_SDK_PATH}/src/rp2040/boot_stage2/boot2_generic_03h.S)
 
 target_compile_definitions(firmware_boot2 PRIVATE
 	PICO_FLASH_SPI_CLKDIV=4

--- a/firmware/sources/hardware/dvi_320x240x256.cpp
+++ b/firmware/sources/hardware/dvi_320x240x256.cpp
@@ -21,6 +21,7 @@
 #include "dvi_serialiser.h"
 #include "system/common_dvi_pin_configs.h"
 #include "hardware/structs/bus_ctrl.h"
+#include "hardware/clocks.h"
 
 // ***************************************************************************************
 //


### PR DESCRIPTION
For RP2050 changes.

Note.

firmware/build/_deps/picodvi-src/software/libdvi/dvi.c has to be currently manually edited.

Line 187 should be

while (dma_debug_hw->ch[inst->dma_cfg[i].chan_data].dbg_tcr != inst->timing->h_active_pixels / DVI_SYMBOLS_PER_WORD)

was originally .tcr
