### PR TITLE
Pin picosdk to 1.5.1

### DIFF
--- a/firmware/pico_sdk_import.cmake
+++ b/firmware/pico_sdk_import.cmake
@@ -34,14 +34,14 @@ if (NOT PICO_SDK_PATH)
             FetchContent_Declare(
                     pico_sdk
                     GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
+                    GIT_TAG 1.5.1
                     GIT_SUBMODULES_RECURSE FALSE
             )
         else ()
             FetchContent_Declare(
                     pico_sdk
                     GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
+                    GIT_TAG 1.5.1
             )
         endif ()
 


### PR DESCRIPTION
I hope this is enough to pin the pico sdk to the last working version.