### PR TITLE
Fix build

### DIFF
--- a/firmware/pico_sdk_import.cmake
+++ b/firmware/pico_sdk_import.cmake
@@ -34,14 +34,14 @@ if (NOT PICO_SDK_PATH)
             FetchContent_Declare(
                     pico_sdk
                     GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
+                    GIT_TAG 1.5.1
                     GIT_SUBMODULES_RECURSE FALSE
             )
         else ()
             FetchContent_Declare(
                     pico_sdk
                     GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
+                    GIT_TAG 1.5.1
             )
         endif ()
 

--- a/firmware/sources/CMakeLists.txt
+++ b/firmware/sources/CMakeLists.txt
@@ -61,7 +61,7 @@ target_compile_definitions(firmware
     PRIVATE PICO_FLASH_SPI_CLKDIV=4
 )
 
-pico_define_boot_stage2(firmware_boot2 ${PICO_SDK_PATH}/src/rp2040/boot_stage2/boot2_generic_03h.S)
+pico_define_boot_stage2(firmware_boot2 ${PICO_SDK_PATH}/src/rp2_common/boot_stage2/boot2_generic_03h.S)
 
 target_compile_definitions(firmware_boot2 PRIVATE
 	PICO_FLASH_SPI_CLKDIV=4


### PR DESCRIPTION
This pins pico sdk to 1.5.1 and fixes the path to the stage2 bootloader.