### PR TITLE
Fixed truncate bug

### DIFF
--- a/firmware/common/sources/interface/fileinterface.cpp
+++ b/firmware/common/sources/interface/fileinterface.cpp
@@ -309,6 +309,13 @@ uint8_t FIOSetFileAttributes(const std::string& filename, uint8_t attribs) {
 // ***************************************************************************************
 
 uint8_t FIOOpenFileHandle(uint8_t fileno, const std::string& filename, uint8_t mode) {
+	if (mode == FIOMODE_RDWR_CREATE) {  											// If open truncate 
+		uint8_t exists;
+		if (FIOExistsFile(filename,&exists) == 0) {  								// If file exists
+			uint8_t error = FIODeleteFile(filename);  								// try to delete it, as we truncate it anyway !
+			if (error) return error;
+		}
+	}
 	return FISOpenFileHandle(fileno, filename, mode);
 }
 


### PR DESCRIPTION
If opened in mode 3 (truncate) checks to see if the file already exists and if so it deletes it.

Fixes #571
