### PR TITLE
Added simple modulation

### DIFF
--- a/basic/test.bsc
+++ b/basic/test.bsc
@@ -1,4 +1,4 @@
-noise 1,220,100
+noise 1,210,100
 end
 
 proc snd(ch,fq,ms,sl,ty,v)


### PR DESCRIPTION
This is a tweak to the white noise. If the white noise frequency is 100Hz or less it plays a pure white noise, if more it plays a modulated effect using the frequency. Values above 8192Hz are reserved for expanded white noise effects.