### PR TITLE
Fixed line numbers at edit error

### DIFF
--- a/basic/scripts/errors.py
+++ b/basic/scripts/errors.py
@@ -35,6 +35,7 @@ errors = """
 	array : 	array not declared
 	hardware : 	hardware error
 	mos : 		mos command error
+	badline : 	illegal line number
 """
 
 err = []

--- a/basic/sources/editing/editing/warmstart.asm
+++ b/basic/sources/editing/editing/warmstart.asm
@@ -40,6 +40,7 @@ WarmStartNoClear:
 
 _WSNotSerialLinkMos:		
 		stz 	ControlStatus 				; clear break flag.
+
 		jsr 	TOKTokenise 				; tokenise it.
 		lda 	tokLineNumber 				; any line number ? if not, execute it.
 		ora 	tokLineNumber+1

--- a/basic/sources/editing/tokenise/tokenise.asm
+++ b/basic/sources/editing/tokenise/tokenise.asm
@@ -26,6 +26,9 @@ TOKTokenise:
 		sta 	tokLineSize 				; line length itself and the line numbers.
 		stz 	tokLineNumber
 		stz 	tokLineNumber+1
+		stz 	ERRLine 					; suppresses line # on error
+		stz 	ERRLine+1
+
 		;
 		stz 	inputPos 					; input position.
 _TOKMainLoop:

--- a/basic/sources/editing/tokenise/workers/tok_intconstant.asm
+++ b/basic/sources/editing/tokenise/workers/tok_intconstant.asm
@@ -47,7 +47,7 @@ _TICLineNumber:
 		sta 	tokLineNumber+1
 		rts
 _TICSyntax:
-		.error_syntax
+		.error_badline
 
 		.send code
 

--- a/basic/test.bsc
+++ b/basic/test.bsc
@@ -1,14 +1,1 @@
-sfx 0,19
-end
-
-proc snd(ch,fq,ms,sl,ty,v)
-	while peek($FF00):wend
-	poke $FF04,ch
-	doke $FF05,fq
-	doke $FF07,ms
-	doke $FF09,sl
-	poke $FF0B,ty
-	poke $FF0C,v
-	poke $FF01,7
-	poke $FF00,8
-endproc
+print "98765";


### PR DESCRIPTION
Fixes #601 

An illegal line number 99999 in the tokeniser creates a syntax error, now it's an illegal line number error. Additionally any line number display of error is suppressed.