### PR TITLE
Serial TCP emulation for Linux emulator

### DIFF
--- a/emulator/Makefile
+++ b/emulator/Makefile
@@ -25,6 +25,7 @@ SOURCES = 	src$(S)core$(S)sys_processor.o src$(S)core$(S)hardware.o src$(S)frame
 			src$(S)framework$(S)main.o src$(S)framework$(S)gfx.o src$(S)framework$(S)debugger.o \
 			src$(S)core$(S)sys_debugger.o  \
 			src$(S)core$(S)6502.o \
+			src$(S)core$(S)serial_tcp.o \
 			$(COMMONOBJECTS)
 
 CC = g++

--- a/emulator/cross-compile/Makefile
+++ b/emulator/cross-compile/Makefile
@@ -26,6 +26,7 @@ COMMONSOURCES = $(wildcard $(IMPSRC)*.cpp)
 SOURCES = 	$(FRASRC)main.cpp $(FRASRC)gfx.cpp $(FRASRC)debugger.cpp $(FRASRC)beeper.cpp \
 			$(EMUSRC)core$(S)sys_processor.cpp  $(EMUSRC)core$(S)sys_debugger.cpp $(EMUSRC)core$(S)hardware.cpp \
 			$(EMUSRC)core$(S)6502.cpp \
+			$(EMUSRC)core$(S)serial_tcp.cpp \
 			$(COMMONSOURCES)
   			
 INCLUDES= -I ../include -I ../framework -I .. -I $(COMDIR)include

--- a/emulator/scripts/wifimodem.py
+++ b/emulator/scripts/wifimodem.py
@@ -1,0 +1,281 @@
+# Experimental Wi-Fi modem emulator for testing TCP serial connection
+
+import socket
+import threading
+import re
+import select
+import binascii
+
+class WifiModemEmulator:
+    def __init__(self, host='localhost', port=25232):
+        self.host = host
+        self.port = port
+        self.server_socket = None
+        self.running = False
+        self.wifi_mode = 1  # Station mode by default
+        self.wifi_connected = False
+        self.ip_address = None
+        self.active_connection = None
+        self.echo_enabled = True  # Echo is enabled by default
+        self.command_buffer = b''
+        self.cipsend_mode = False
+        self.cipsend_length = 0
+        self.client_socket = None
+
+    def start(self):
+        self.running = True
+        self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.server_socket.bind((self.host, self.port))
+        self.server_socket.listen(1)
+
+        print(f"Wi-Fi Modem Emulator listening on {self.host}:{self.port}")
+        while self.running:
+            client_socket, addr = self.server_socket.accept()
+            print(f"Connected by {addr}")
+            client_thread = threading.Thread(target=self.handle_client, args=(client_socket,))
+            client_thread.start()
+
+    def handle_client(self, client_socket):
+        self.client_socket = client_socket
+        self.command_buffer = b''
+        while self.running:
+            try:
+                data = client_socket.recv(1024)
+                if not data:
+                    break
+                
+                print("\n--- Received data from client ---")
+                print("Hexdump:")
+                print(self.hexdump(data))
+                print("--- End of received data ---\n")
+                
+                self.command_buffer += data
+                
+                while self.command_buffer:
+                    if self.cipsend_mode:
+                        if len(self.command_buffer) >= self.cipsend_length:
+                            send_data = self.command_buffer[:self.cipsend_length]
+                            self.handle_cipsend_data(client_socket, send_data)
+                            self.command_buffer = self.command_buffer[self.cipsend_length:]
+                        else:
+                            break  # Wait for more data
+                    else:
+                        if b'\r\n' in self.command_buffer:
+                            command, self.command_buffer = self.command_buffer.split(b'\r\n', 1)
+                            command = command.strip().decode('utf-8', errors='ignore')
+                            if command:
+                                print(f"Received command: {command}")
+                                response = self.process_command(command)
+                                
+                                print("\n--- Sending data to client ---")
+                                print("Hexdump:")
+                                print(self.hexdump(response.encode('utf-8')))
+                                print("--- End of sent data ---\n")
+                                
+                                client_socket.sendall(response.encode('utf-8'))
+                        else:
+                            break  # Wait for more data
+                        
+            except Exception as e:
+                print(f"Error handling client: {e}")
+                break
+        self.client_socket = None
+        client_socket.close()
+
+    def process_command(self, command):
+        # Convert command to uppercase for case-insensitive matching
+        upper_command = command.upper()
+        
+        if self.echo_enabled:
+            echo_response = command + '\r\n'
+        else:
+            echo_response = ''
+
+        if upper_command == "AT":
+            return echo_response + "OK\r\n"
+        elif upper_command == "AT+RST":
+            return echo_response + "OK\r\n"
+        elif upper_command.startswith("AT+CWMODE"):
+            return echo_response + self.handle_cwmode(upper_command)
+        elif upper_command.startswith("AT+CWJAP"):
+            return echo_response + self.handle_cwjap(upper_command)
+        elif upper_command == "AT+CIFSR":
+            return echo_response + self.handle_cifsr()
+        elif upper_command.startswith("AT+CIPSTART"):
+            return echo_response + self.handle_cipstart(upper_command)
+        elif upper_command.startswith("AT+CIPSEND"):
+            return echo_response + self.handle_cipsend(upper_command)
+        elif upper_command == "AT+CIPCLOSE":
+            return echo_response + self.handle_cipclose()
+        elif upper_command in ["ATE", "ATE1"]:
+            return self.handle_ate(True)
+        elif upper_command == "ATE0":
+            return self.handle_ate(False)
+        elif upper_command == "AT+CIPSTATUS":
+            return echo_response + self.handle_cipstatus()
+        else:
+            print(f"DEBUG: Unrecognized command: {command}")
+            return echo_response + "ERROR\r\n"
+
+    def handle_cwmode(self, command):
+        mode = re.search(r'AT\+CWMODE=(\d)', command)
+        if mode:
+            self.wifi_mode = int(mode.group(1))
+            return "OK\r\n"
+        return "ERROR\r\n"
+
+    def handle_cwjap(self, command):
+        self.wifi_connected = True
+        self.ip_address = "192.168.1.100"
+        return "WIFI CONNECTED\r\nWIFI GOT IP\r\n\r\nOK\r\n"
+
+    def handle_cifsr(self):
+        response = ""
+        if self.ip_address:
+            response += f"+CIFSR:STAIP,\"{self.ip_address}\"\r\n"
+        if self.wifi_mode in [2, 3]:  # AP or AP+STA mode
+            response += f"+CIFSR:APIP,\"192.168.4.1\"\r\n"
+        return response + "\r\nOK\r\n" if response else "ERROR\r\n"
+
+    def handle_cipstart(self, command):
+        match = re.search(r'AT\+CIPSTART="(\w+)","(.+)",(\d+)', command)
+        if match:
+            protocol, host, port = match.groups()
+            try:
+                self.active_connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                self.active_connection.connect((host, int(port)))
+                # Start a new thread to read from the active connection
+                threading.Thread(target=self.read_from_active_connection, daemon=True).start()
+                return "CONNECT\r\n\r\nOK\r\n"
+            except Exception as e:
+                print(f"Failed to connect: {e}")
+                self.active_connection = None
+                return "ERROR\r\n"
+        return "ERROR\r\n"
+
+    def handle_cipsend(self, command):
+        match = re.search(r'AT\+CIPSEND=(\d+)', command)
+        if match and self.active_connection:
+            self.cipsend_length = int(match.group(1))
+            self.cipsend_mode = True
+            return "OK\r\n> "
+        return "ERROR\r\n"
+
+    def handle_cipsend_data(self, client_socket, data):
+        print("\n--- Sending data to server ---")
+        print("Hexdump:")
+        print(self.hexdump(data))
+        print("--- End of sent data ---\n")
+        
+        try:
+            self.active_connection.sendall(data)
+            response = "SEND OK\r\n"
+            
+            print("\n--- Sending data to client ---")
+            print("Hexdump:")
+            print(self.hexdump(response.encode('utf-8')))
+            print("--- End of sent data ---\n")
+            
+            client_socket.sendall(response.encode('utf-8'))
+        except Exception as e:
+            print(f"Failed to send data: {e}")
+            error_response = "ERROR\r\n"
+            
+            print("\n--- Sending error to client ---")
+            print("Hexdump:")
+            print(self.hexdump(error_response.encode('utf-8')))
+            print("--- End of sent data ---\n")
+            
+            client_socket.sendall(error_response.encode('utf-8'))
+        self.cipsend_mode = False
+
+    def read_from_active_connection(self):
+        buffer_size = 8192  # 8K buffer
+        while self.active_connection and self.running:
+            try:
+                ready, _, _ = select.select([self.active_connection], [], [], 1)
+                if ready:
+                    data = self.active_connection.recv(buffer_size)
+                    if data:
+                        print("\n--- Received data from server ---")
+                        print("Hexdump:")
+                        print(self.hexdump(data))
+                        print("--- End of received data ---\n")
+
+                        if self.client_socket:
+                            # Format the +IPD message
+                            ipd_msg = f"+IPD,{len(data)}:"
+                            response = ipd_msg.encode('ascii') + data
+
+                            print("\n--- Sending data to client ---")
+                            print("Hexdump:")
+                            print(self.hexdump(response))
+                            print("--- End of sent data ---\n")
+
+                            self.client_socket.sendall(response)
+                    else:
+                        # Connection closed by the server
+                        print("Server closed the connection")
+                        self.handle_cipclose()
+                        break
+            except Exception as e:
+                print(f"Error reading from active connection: {e}")
+                self.handle_cipclose()
+                break
+
+    def handle_cipclose(self):
+        if self.active_connection:
+            self.active_connection.close()
+            self.active_connection = None
+        if self.client_socket:
+            response = "CLOSED\r\n"
+            
+            print("\n--- Sending data to client ---")
+            print("Hexdump:")
+            print(self.hexdump(response.encode('utf-8')))
+            print("--- End of sent data ---\n")
+            
+            self.client_socket.sendall(response.encode('utf-8'))
+        self.cipsend_mode = False
+        self.cipsend_length = 0
+        return "OK\r\n"
+
+    def handle_ate(self, enable):
+        self.echo_enabled = enable
+        return "OK\r\n"
+
+    def handle_cipstatus(self):
+        response = "STATUS:2\r\n"  # Assuming 2 means "Got IP"
+        if self.active_connection:
+            response += "+CIPSTATUS:0,\"TCP\",\"" + self.active_connection.getpeername()[0] + "\"," + str(self.active_connection.getpeername()[1]) + ",0\r\n"
+        return response + "\r\nOK\r\n"
+
+    def hexdump(self, data):
+        def grouped(iterable, n):
+            return zip(*[iter(iterable)]*n)
+
+        result = []
+        for i, chunk in enumerate(grouped(binascii.hexlify(data).decode(), 32)):
+            hex_line = ' '.join(''.join(pair) for pair in grouped(chunk, 2))
+            ascii_line = ''.join(chr(b) if 32 <= b < 127 else '.' for b in data[i*16:(i+1)*16])
+            result.append(f"{i*16:04x}: {hex_line:<48}  {ascii_line}")
+        return '\n'.join(result)
+
+    def stop(self):
+        self.running = False
+        if self.server_socket:
+            self.server_socket.close()
+        if self.active_connection:
+            self.active_connection.close()
+        if self.client_socket:
+            self.client_socket.close()
+
+if __name__ == "__main__":
+    emulator = WifiModemEmulator()
+    try:
+        emulator.start()
+    except KeyboardInterrupt:
+        print("Stopping the emulator...")
+    finally:
+        emulator.stop()

--- a/emulator/src/core/serial_emu.h
+++ b/emulator/src/core/serial_emu.h
@@ -1,0 +1,31 @@
+#ifndef SERIAL_EMU_H
+#define SERIAL_EMU_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    bool (*isByteAvailable)(void);
+    uint8_t (*readByte)(void);
+    void (*writeByte)(uint8_t b);
+    void (*setSerialFormat)(uint32_t baudRate, uint32_t protocol);
+    void (*cleanup)(void);
+} SerialInterface;
+
+enum SerialType {
+    SER_STUB,
+    SER_TCP
+};
+
+// Function to open and return the appropriate SerialInterface
+const SerialInterface* SerialInterfaceOpen(enum SerialType type);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SERIAL_EMU_H

--- a/emulator/src/core/serial_tcp.cpp
+++ b/emulator/src/core/serial_tcp.cpp
@@ -1,0 +1,184 @@
+// *******************************************************************************************************************************
+// *******************************************************************************************************************************
+//
+//		Name:		serial_tcp.cpp
+//		Purpose:	Serial Port emulation via TCP
+//		Created:	6th Septemper 2024
+//		Author:		Joonas Viskari (joonas.viskari@gmail.com)
+//
+// *******************************************************************************************************************************
+// *******************************************************************************************************************************
+
+
+#include "serial_emu.h"
+
+#ifdef LINUX
+// Only supported on Linux at the moment
+#define TCPSERIAL_SUPPORT
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <stdio.h>
+
+#ifdef TCPSERIAL_SUPPORT
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <ctype.h> // isprint
+#define TCP_PORT 25232
+#define BUFFER_SIZE 1024
+
+// IP232 (TCP client wrapper) implementation
+static int sockfd = -1;
+static struct sockaddr_in server_addr;
+static char buffer[BUFFER_SIZE];
+static int buffer_pos = 0;
+static int buffer_size = 0;
+
+
+static char debug_printable(char c) {
+    if (isprint((unsigned char)c)) {
+        return c;
+    } else {
+        return ' ';
+    }
+}
+
+
+static bool tcpsByteAvailableImpl(void) {
+    if (buffer_pos < buffer_size) {
+        return true;
+    }
+
+    buffer_pos = 0;
+    buffer_size = recv(sockfd, buffer, BUFFER_SIZE, MSG_DONTWAIT);
+    if (buffer_size > 0) {
+        return true;
+    }
+    return false;
+}
+
+static uint8_t tcpReadByteImpl(void) {
+
+    if (tcpsByteAvailableImpl()) {
+        if (buffer_pos < buffer_size) {
+            char c = buffer[buffer_pos];
+            printf("TCP(r):  %02X | %c \n", c, debug_printable(c));
+            return (uint8_t)buffer[buffer_pos++];
+        }
+    }
+    return 0;
+}
+
+static void tcpWriteByteImpl(uint8_t b) {
+    if (sockfd >= 0) {
+        char byte = (char)b;
+        send(sockfd, &byte, 1, MSG_DONTWAIT);
+    }
+    printf("TCP(w): %02X | %c \n", b, debug_printable(b));
+}
+
+static void tcpSetSerialFormatImpl(uint32_t baudRate, uint32_t protocol) {
+    printf("TCP Setting Serial to %d baud protocol %d.\n", baudRate, protocol);
+}
+
+static void tcpCleanupImpl(void) {
+    if (sockfd >= 0) {
+        close(sockfd);
+        sockfd = -1;
+    }
+}
+
+static bool openTcpSocket() {
+    sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (sockfd < 0) {
+        perror("Error creating socket");
+        return false;
+    }
+
+    memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+    server_addr.sin_port = htons(TCP_PORT);
+
+    if (connect(sockfd, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
+        perror("Error connecting to server");
+        close(sockfd);
+        sockfd = -1;
+        return false;
+    }
+
+    int flags = fcntl(sockfd, F_GETFL, 0);
+    fcntl(sockfd, F_SETFL, flags | O_NONBLOCK);
+
+    printf("TCP Connected to server on port %d\n", TCP_PORT);
+    return true;
+}
+
+
+// Static SerialInterface instances
+static const SerialInterface gSerialInterfaceIP232 = {
+    .isByteAvailable = tcpsByteAvailableImpl,
+    .readByte = tcpReadByteImpl,
+    .writeByte = tcpWriteByteImpl,
+    .setSerialFormat = tcpSetSerialFormatImpl,
+    .cleanup = tcpCleanupImpl
+};
+#endif
+
+// STUB implementation
+static bool stubIsByteAvailableImpl(void) {
+    return false;
+}
+
+static uint8_t stubReadByteImpl(void) {
+    return 0;
+}
+
+static void stubWriteByteImpl(uint8_t b) {
+    (void)b;
+    printf("STUB Serial write %d\n", b);
+}
+
+static void stubSetSerialFormatImpl(uint32_t baudRate, uint32_t protocol) {
+    (void)baudRate;
+    (void)protocol;
+    printf("STUB Setting Serial to %d baud protocol %d.\n", baudRate, protocol);
+}
+
+static void stubCleanupImpl(void) {
+    // Nothing to clean up for stub
+}
+
+static const SerialInterface gSerialInterfaceStub = {
+    .isByteAvailable = stubIsByteAvailableImpl,
+    .readByte = stubReadByteImpl,
+    .writeByte = stubWriteByteImpl,
+    .setSerialFormat = stubSetSerialFormatImpl,
+    .cleanup = stubCleanupImpl
+};
+
+
+// Function to open and return the appropriate SerialInterface
+const SerialInterface* SerialInterfaceOpen(enum SerialType type) {
+    switch (type) {
+        case SER_TCP:
+#ifdef TCPSERIAL_SUPPORT        
+            if (openTcpSocket()) {
+                return &gSerialInterfaceIP232;
+            }
+#endif            
+            printf("Failed to open TCP socket. Falling back to STUB implementation.\n");
+            // Fall through to SER_STUB if socket opening fails
+        case SER_STUB:
+            return &gSerialInterfaceStub;
+        default:
+            return NULL;
+    }
+}


### PR DESCRIPTION
Serial port is emulated by opening TCP connection to local port 25232. If the server is not online, serial port handling falls back to stub implementation.

This enables testing the serial port operations by using tools such as  socat, nc etc. Also modem emulation is possible using tcpser or included wifimodem.py.