### PR TITLE
Increase 65c02 clock

### DIFF
--- a/firmware/common/sources/interface/keyboard.cpp
+++ b/firmware/common/sources/interface/keyboard.cpp
@@ -3,6 +3,7 @@
 //
 //      Name :      keyboard.cpp
 //      Authors :   Paul Robson (paul@robsons.org.uk)
+//									Angel Sancho
 //      Date :      21st November 2023
 //      Reviewed :  No
 //      Purpose :   Converts keyboard events to a queue and key state array.
@@ -15,6 +16,7 @@
 
 #define MAX_QUEUE_SIZE (64) 													// Max size of keyboard queue.
 #define MAX_FKEY_SIZE (48)   													// Max length of function key.
+#define QUEUE_MASK (MAX_QUEUE_SIZE-1)
 
 //
 //		Bit patterns for the key states. These represent the key codes (see kbdcodes.h)
@@ -27,7 +29,8 @@ static uint8_t keyboardModifiers;
 //		Queue of ASCII keycode presses.
 //
 static uint8_t queue[MAX_QUEUE_SIZE+1];
-static uint8_t queueSize = 0;
+static volatile uint8_t queueHead = 0;
+static volatile uint8_t queueTail = 0;
 
 static uint8_t currentASCII = 0,currentKeyCode = 0; 							// Current key pressed.
 static uint32_t nextRepeat = 9999;  											// Time of next repeat.
@@ -50,7 +53,8 @@ void KBDEvent(uint8_t isDown,uint8_t keyCode,uint8_t modifiers) {
 	}
 
 	if (keyCode == 0xFF) { 														// Reset request
-		queueSize = 0; 															// Empty keyboard queue
+		queueHead = 0; 															// Empty keyboard queue
+		queueTail = 0; 															// Empty keyboard queue
 		for (unsigned int i = 0;i < sizeof(keyboardState);i++) {   				// No keys down.
 			keyboardState[i] = 0; 
 		}
@@ -82,7 +86,7 @@ void KBDEvent(uint8_t isDown,uint8_t keyCode,uint8_t modifiers) {
 //
 // ***************************************************************************************
 
-void KBDCheckTimer(void) {
+void __time_critical_func(KBDCheckTimer)(void) {
 	if (currentASCII != 0) {  													// Key pressed
 		if (TMRRead() >= nextRepeat) {  										// Time up ?
 			KBDInsertQueue(currentASCII);  										// Put in queue
@@ -117,10 +121,10 @@ uint8_t KBDGetModifiers(void) {
 // ***************************************************************************************
 
 void KBDInsertQueue(uint8_t ascii) {
-	if (queueSize < MAX_QUEUE_SIZE) {   										// Do we have a full queue ?
-		queue[queueSize] = ascii;  												// If not insert it.
-		queueSize++;
-	}
+	uint8_t next = (queueTail + 1) & QUEUE_MASK;
+    if (next == queueHead) return;        // full
+    queue[queueTail] = ascii;
+    queueTail = next;
 }
 
 // ***************************************************************************************
@@ -130,7 +134,7 @@ void KBDInsertQueue(uint8_t ascii) {
 // ***************************************************************************************
 
 bool KBDIsKeyAvailable(void) {
-	return queueSize != 0;
+	return (queueHead != queueTail);
 }
 
 // ***************************************************************************************
@@ -140,11 +144,10 @@ bool KBDIsKeyAvailable(void) {
 // ***************************************************************************************
 
 uint8_t KBDGetKey(void) {
-	if (queueSize == 0) return 0; 												// Queue empty.
-	uint8_t key = queue[0];
-	for (uint8_t i = 0;i < queueSize;i++) queue[i] = queue[i+1];  				// Dequeue it
-	queueSize--;
-	return key;
+	if (queueHead == queueTail) return 0;            // empty
+    uint8_t key = queue[queueHead];
+    queueHead = (queueHead + 1) & QUEUE_MASK;
+    return key;
 }
 
 // ***************************************************************************************
@@ -321,5 +324,6 @@ uint8_t KBDKeyboardController(void) {
 //		18-02-24	Keys WASDOP now default keys, also cursor keys.
 //		17-03-24 	Added ZX control keys.
 //		25-03-24 	Extended to support ABXY in the basic API structure.
+//		13-03-26  Optimized keyboard queue
 //	
 // ***************************************************************************************

--- a/firmware/sources/hardware/usbdriver.cpp
+++ b/firmware/sources/hardware/usbdriver.cpp
@@ -5,6 +5,7 @@
 //      Authors :   Tsvetan Usunov (Olimex)
 //                  Paul Robson (paul@robsons.org.uk)
 //                  Sascha Schneider
+//                  Angel Sancho
 //      Date :      20th November 2023
 //      Reviewed :  No
 //      Purpose :   USB interface and HID->Event mapper.
@@ -150,13 +151,18 @@ uint32_t GMPReadDigitalController(uint8_t index) {
 // ***************************************************************************************
 
 void __time_critical_func(KBDSync)(void) {
-    tuh_task();
+    if (tuh_task_event_ready()) {
+      tuh_task_ext(0, false);
+    }
+    
     KBDCheckTimer();
+    
 }
 
 // ***************************************************************************************
 //
 //      Date        Revision
 //      ====        ========
+//		 13-03-26     Optimized tuh_task call
 //
 // ***************************************************************************************

--- a/firmware/sources/system/processor_pio.cpp
+++ b/firmware/sources/system/processor_pio.cpp
@@ -5,6 +5,7 @@
 //      Authors :   Sascha Schneider
 //                  Oliver Schmidt
 //                  Rien Matthijsse
+//                  Angel Sancho
 //      Date :      8th December 2023
 //      Reviewed :  No
 //      Purpose :   Drive the 65C02 processor via PIO
@@ -47,26 +48,51 @@ void __time_critical_func(CPUExecute)(void) {
             uint8_t flags;
         } data;
     } value;
+    
     uint16_t count = 0;
-
+    uint8_t consecutive_writes = 0;
+    const uint16_t cp = CONTROLPORT;
+    
     while (1) {
-        value.value = pio_sm_get_blocking(pio1, 0);
-
-        if (value.data.flags & 0x8) { // 65C02 Read
-
-            pio_sm_put(pio1, 0, cpuMemory[value.data.address]);
-
-        } else { // 65C02 Write
-
-            uint8_t data = pio_sm_get_blocking(pio1, 0);
-
-            cpuMemory[value.data.address] = data;
-            if (value.data.address == CONTROLPORT && data) {
-                DSPHandler(cpuMemory + controlPort, cpuMemory);
-            }
-
+        // Ensures synchronization with the PIO during W65C02 interrupts
+        if(consecutive_writes < 3) {
+            value.value = pio_sm_get(pio1, 0);
+        } else {
+            consecutive_writes = 0;
+            value.value = pio_sm_get_blocking(pio1, 0);
         }
-
+      
+        if (value.data.flags & 0x8) { // 65C02 Read
+            pio_sm_put(pio1, 0, cpuMemory[value.data.address]);
+            
+            consecutive_writes = 0;
+            
+            __asm volatile (
+              "nop; nop; nop; nop\n\t"
+              "nop; nop; nop; nop\n\t"
+              "nop; nop; nop; nop\n\t"
+              "nop; nop\n\t"
+              ::: "memory"
+            );
+          
+        } else { // 65C02 Write
+            consecutive_writes++;
+            
+            // Safe to do without blocking since the PIO state machine always finishes first
+            cpuMemory[value.data.address] = pio_sm_get(pio1, 0);
+            
+            if ((uint8_t)value.value == 0x00) {
+                if (value.data.address == cp) {
+                    DSPHandler(cpuMemory + controlPort, cpuMemory);
+                }
+            }
+            
+            __asm volatile (
+              "nop\n"
+              ::: "memory"
+            );
+        }
+        
         if (!count++) {
             DSPSync();
         }
@@ -77,5 +103,6 @@ void __time_critical_func(CPUExecute)(void) {
 //
 //      Date        Revision
 //      ====        ========
+//		 13-03-26     Optimized main CPU loop and PIO state machine code
 //
 // ***************************************************************************************

--- a/firmware/sources/system/sm0_memory_emulation_with_clock.pio
+++ b/firmware/sources/system/sm0_memory_emulation_with_clock.pio
@@ -2,17 +2,20 @@
 .side_set 1 opt
 .wrap_target
 start:
-    set pins, 0b110 side 1  [6] ; activate A0-A7, side 1 is clock high
-    in  pins, 8                 ; read 8 bits
-    set pins, 0b101         [5] ; activate A8-A15
-    in  pins, 24                ; read 8 bits, OEs, r/w bit and some random bits
-    set pins, 0b011         [4] ; activate D0-D7
+    set pins, 0b101  side 1  [5] ; activate A8-A15
+    in  pins, 24                 ; read 8 bits, OEs, r/w bit and some random bits
+    set pins, 0b110          [4] ; activate A0-A7, side 1 is clock high
+    mov osr, ~null               ; preload osr with OUT value for pindirs
+    in  pins, 8                  ; read 8 bits
+    set pins, 0b011              ; activate D0-D7
     jmp pin read
-    in  pins, 32                ; read data and some random bits
-    jmp start       side 0  [3] ; side 0 is clock low
+    out null, 8                  ; discard osr (write cycle)
+    nop                      [2]
+    in  pins, 32    side 0   [3] ; read data and some random bits, side 0 is clock low
+    jmp start
+    
 read:
-    mov osr, ~null              ; set pins 0-7 to OUT
-    out pindirs, 8
+    out pindirs, 8              ; set pins 0-7 to OUT
     out pins, 8                 ; Write out data
     mov osr, null               ; set pins 0-7 to IN
     out pindirs, 8  side 0  [4] ; side 0 is clock low
@@ -39,7 +42,7 @@ void memory_emulation_with_clock_program_init(PIO pio, uint sm, uint offset) {
     pio_sm_set_consecutive_pindirs(pio, sm, 21, 1, true);
 
     pio_sm_config c = memory_emulation_with_clock_program_get_default_config(offset);
-
+    
     sm_config_set_set_pins(&c, 8, 3);
 
     sm_config_set_in_pins(&c, 0);
@@ -48,7 +51,7 @@ void memory_emulation_with_clock_program_init(PIO pio, uint sm, uint offset) {
 
     sm_config_set_sideset_pins(&c, 21);
 
-    sm_config_set_in_shift(&c, true, true, 32);
+    sm_config_set_in_shift(&c, false, true, 32);
 
     sm_config_set_out_shift(&c, true, true, 8);
 


### PR DESCRIPTION
This PR improves main cpu loop and PIO state machine and allows the Neo6502 to run at ~7.6 MHz

Small changes in tuh_task call and optimized keyboard queue

Test mandelbrot:

Original:  10.17s
Optimized:  8.32s

BM1: 0.583
BM2: 0.358
BM3: 0.738
BM4: 0.682
BM5: 0.852
BM6: 1.276
BM7: 2.204
BM8: 0.077

Commit reference: aa5aff952fe3a8ee5690258b41d4321cea06bb6a