### PR TITLE
emulator: case-insensitive .neo extension match for cold-boot auto-load

### DIFF
--- a/emulator/src/core/sys_processor.cpp
+++ b/emulator/src/core/sys_processor.cpp
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <ctype.h>
 #include <cstdint>
 #include "sys_processor.h"
@@ -168,8 +169,8 @@ void CPUReset(void) {
 			if (strcmp(command,"trace") == 0) { 									// Dump every CPU instruction to stdout.
 				traceMode = true;
 			}
-			if (strlen(command) > 4 && 												// Load .NEO file.
-						strcmp(command+strlen(command)-4,".neo") == 0) {
+			if (strlen(command) > 4 && 												// Load .NEO file (case-insensitive
+						strcasecmp(command+strlen(command)-4,".neo") == 0) {	// so FTD.NEO / Foo.Neo also match).
 				CPUReadNeoFile(command);
 			}
 		}


### PR DESCRIPTION
The CPUReset cmdline arg parser uses strcmp against ".neo" to detect .neo containers and trigger CPUReadNeoFile. On case-sensitive filesystems (Linux, macOS) this means foo.NEO / Foo.Neo fall through to the monitor instead of auto-loading + cold-booting from $800.

Retro toolchains commonly emit uppercase .NEO (matching the SD-card/8.3 convention shared with X16/Commodore lineage tooling), so users on Linux hit this without warning. The comment on this branch already says "Load .NEO file" -- the implementation just hadn't matched its own intent.

Switched strcmp to strcasecmp (and added <strings.h>). FTD.NEO, foo.neo, and Foo.Neo now all auto-load as expected.