### PR TITLE
ci: bump actions/upload-artifact v3 -> v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       run: make
 
     - name: 'Upload Artifact'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release
         path: release/neo6502.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: make
 
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release
           path: release/neo6502.zip


### PR DESCRIPTION
`actions/upload-artifact@v3` was hard-deprecated on 2024-01-30 and now fails every workflow run with:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

This PR bumps both workflows (`build.yml` + `release.yml`) to `@v4`. The single-artifact-per-run pattern used here doesn't hit any of v4's breaking changes (no merge across multiple uploads of the same name; the `xresloader/upload-to-github-release` step in `release.yml` reads the file directly from the workspace, not via `download-artifact`).

`actions/checkout@v3` is also deprecated and will start failing in turn — happy to send a follow-up for that separately if useful.

Tested by pushing to my fork's `ci/upload-artifact-v4` branch — CI ran clean. Reference: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/